### PR TITLE
SK-546 Removal of Grace Period of 5 mins

### DIFF
--- a/src/main/java/com/skyflow/common/utils/TokenUtils.java
+++ b/src/main/java/com/skyflow/common/utils/TokenUtils.java
@@ -50,7 +50,6 @@ public final class TokenUtils {
 
     private static boolean isExpired(String encodedToken) throws ParseException, SkyflowException {
         long currentTime = new Date().getTime() / 1000;
-        currentTime = currentTime + 300;
         long expiryTime = (long) decoded(encodedToken).get("exp");
         return currentTime > expiryTime;
     }


### PR DESCRIPTION
## Removal of Grace Period of 5 mins

- Removed 5 mins of grace period for cache refresh of bearer token
- Issue [SK-546](https://skyflow.atlassian.net/browse/SK-546)

[SK-546]: https://skyflow.atlassian.net/browse/SK-546?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ