### PR TITLE
SK-1802 Fix inconsistencies in SDK v2

### DIFF
--- a/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -8,7 +8,7 @@ public enum ErrorMessage {
     VaultIdNotInConfigList("%s0 Validation error. VaultId is missing from the config. Specify the vaultIds from configs."),
     ConnectionIdAlreadyInConfigList("%s0 Validation error. ConnectionId is present in an existing config. Specify a connectionId in config."),
     ConnectionIdNotInConfigList("%s0 Validation error. ConnectionId is missing from the config. Specify the connectionIds from configs."),
-    EmptyCredentials("%s0 Validation error. Invalid credentials. Specify a valid credentials."),
+    EmptyCredentials("%s0 Validation error. Invalid credentials. Credentials must not be empty."),
 
     // vault config
     InvalidVaultId("%s0 Initialization failed. Invalid vault ID. Specify a valid vault ID."),

--- a/src/main/java/com/skyflow/utils/Constants.java
+++ b/src/main/java/com/skyflow/utils/Constants.java
@@ -16,4 +16,12 @@ public final class Constants {
     public static final String SDK_NAME = "Skyflow Java SDK ";
     public static final String SDK_VERSION = "v2";
     public static final String SDK_PREFIX = SDK_NAME + SDK_VERSION;
+    public static final String SDK_METRIC_NAME_VERSION = "sdk_name_version";
+    public static final String SDK_METRIC_NAME_VERSION_PREFIX = "skyflow-java@";
+    public static final String SDK_METRIC_CLIENT_DEVICE_MODEL = "sdk_client_device_model";
+    public static final String SDK_METRIC_CLIENT_OS_DETAILS = "sdk_client_os_details";
+    public static final String SDK_METRIC_RUNTIME_DETAILS = "sdk_runtime_details";
+    public static final String SDK_METRIC_RUNTIME_DETAILS_PREFIX = "Java@";
+    public static final String SDK_AUTH_HEADER_KEY = "x-skyflow-authorization";
+    public static final String SDK_METRICS_HEADER_KEY = "sky-metadata";
 }

--- a/src/main/java/com/skyflow/utils/Utils.java
+++ b/src/main/java/com/skyflow/utils/Utils.java
@@ -1,5 +1,6 @@
 package com.skyflow.utils;
 
+import com.google.gson.JsonObject;
 import com.skyflow.config.ConnectionConfig;
 import com.skyflow.config.Credentials;
 import com.skyflow.enums.Env;
@@ -7,6 +8,7 @@ import com.skyflow.errors.ErrorCode;
 import com.skyflow.errors.ErrorMessage;
 import com.skyflow.errors.SkyflowException;
 import com.skyflow.logs.ErrorLogs;
+import com.skyflow.logs.InfoLogs;
 import com.skyflow.serviceaccount.util.BearerToken;
 import com.skyflow.utils.logger.LogUtil;
 import com.skyflow.vault.connection.InvokeConnectionRequest;
@@ -99,23 +101,6 @@ public final class Utils {
         return base;
     }
 
-    private static PrivateKey parsePkcs8PrivateKey(byte[] pkcs8Bytes) throws SkyflowException {
-        KeyFactory keyFactory;
-        PrivateKey privateKey = null;
-        try {
-            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pkcs8Bytes);
-            keyFactory = KeyFactory.getInstance("RSA");
-            privateKey = keyFactory.generatePrivate(keySpec);
-        } catch (NoSuchAlgorithmException e) {
-            LogUtil.printErrorLog(ErrorLogs.INVALID_ALGORITHM.getLog());
-            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidAlgorithm.getMessage());
-        } catch (InvalidKeySpecException e) {
-            LogUtil.printErrorLog(ErrorLogs.INVALID_KEY_SPEC.getLog());
-            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidKeySpec.getMessage());
-        }
-        return privateKey;
-    }
-
     public static String constructConnectionURL(ConnectionConfig config, InvokeConnectionRequest invokeConnectionRequest) {
         StringBuilder filledURL = new StringBuilder(config.getConnectionUrl());
 
@@ -150,4 +135,68 @@ public final class Utils {
         return headersMap;
     }
 
+    public static JsonObject getMetrics() {
+        JsonObject details = new JsonObject();
+        String sdkVersion = Constants.SDK_VERSION;
+        String deviceModel;
+        String osDetails;
+        String javaVersion;
+        // Retrieve device model
+        try {
+            deviceModel = System.getProperty("os.name");
+            if (deviceModel == null) throw new Exception();
+        } catch (Exception e) {
+            LogUtil.printInfoLog(parameterizedString(
+                    InfoLogs.UNABLE_TO_GENERATE_SDK_METRIC.getLog(),
+                    Constants.SDK_METRIC_CLIENT_DEVICE_MODEL
+            ));
+            deviceModel = "";
+        }
+
+        // Retrieve OS details
+        try {
+            osDetails = System.getProperty("os.version");
+            if (osDetails == null) throw new Exception();
+        } catch (Exception e) {
+            LogUtil.printInfoLog(parameterizedString(
+                    InfoLogs.UNABLE_TO_GENERATE_SDK_METRIC.getLog(),
+                    Constants.SDK_METRIC_CLIENT_OS_DETAILS
+            ));
+            osDetails = "";
+        }
+
+        // Retrieve Java version details
+        try {
+            javaVersion = System.getProperty("java.version");
+            if (javaVersion == null) throw new Exception();
+        } catch (Exception e) {
+            LogUtil.printInfoLog(parameterizedString(
+                    InfoLogs.UNABLE_TO_GENERATE_SDK_METRIC.getLog(),
+                    Constants.SDK_METRIC_RUNTIME_DETAILS
+            ));
+            javaVersion = "";
+        }
+        details.addProperty(Constants.SDK_METRIC_NAME_VERSION, Constants.SDK_METRIC_NAME_VERSION_PREFIX + sdkVersion);
+        details.addProperty(Constants.SDK_METRIC_CLIENT_DEVICE_MODEL, deviceModel);
+        details.addProperty(Constants.SDK_METRIC_RUNTIME_DETAILS, Constants.SDK_METRIC_RUNTIME_DETAILS_PREFIX + javaVersion);
+        details.addProperty(Constants.SDK_METRIC_CLIENT_OS_DETAILS, osDetails);
+        return details;
+    }
+
+    private static PrivateKey parsePkcs8PrivateKey(byte[] pkcs8Bytes) throws SkyflowException {
+        KeyFactory keyFactory;
+        PrivateKey privateKey = null;
+        try {
+            PKCS8EncodedKeySpec keySpec = new PKCS8EncodedKeySpec(pkcs8Bytes);
+            keyFactory = KeyFactory.getInstance("RSA");
+            privateKey = keyFactory.generatePrivate(keySpec);
+        } catch (NoSuchAlgorithmException e) {
+            LogUtil.printErrorLog(ErrorLogs.INVALID_ALGORITHM.getLog());
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidAlgorithm.getMessage());
+        } catch (InvalidKeySpecException e) {
+            LogUtil.printErrorLog(ErrorLogs.INVALID_KEY_SPEC.getLog());
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidKeySpec.getMessage());
+        }
+        return privateKey;
+    }
 }

--- a/src/main/java/com/skyflow/vault/connection/InvokeConnectionResponse.java
+++ b/src/main/java/com/skyflow/vault/connection/InvokeConnectionResponse.java
@@ -1,6 +1,8 @@
 package com.skyflow.vault.connection;
 
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 
 public class InvokeConnectionResponse {
     private JsonObject response;
@@ -9,10 +11,15 @@ public class InvokeConnectionResponse {
         this.response = response;
     }
 
+    public JsonObject getResponse() {
+        return response;
+    }
+
     @Override
     public String toString() {
-        return "InvokeConnectionResponse{" +
-                "response=" + response +
-                '}';
+        Gson gson = new Gson();
+        JsonObject responseObject = JsonParser.parseString(gson.toJson(this)).getAsJsonObject();
+        responseObject = responseObject.remove("response").getAsJsonObject();
+        return responseObject.toString();
     }
 }

--- a/src/main/java/com/skyflow/vault/controller/ConnectionController.java
+++ b/src/main/java/com/skyflow/vault/controller/ConnectionController.java
@@ -13,6 +13,7 @@ import com.skyflow.errors.ErrorMessage;
 import com.skyflow.errors.SkyflowException;
 import com.skyflow.logs.ErrorLogs;
 import com.skyflow.logs.InfoLogs;
+import com.skyflow.utils.Constants;
 import com.skyflow.utils.HttpUtility;
 import com.skyflow.utils.Utils;
 import com.skyflow.utils.logger.LogUtil;
@@ -44,8 +45,9 @@ public class ConnectionController extends ConnectionClient {
             if (requestHeaders != null && requestHeaders.containsKey("requestHeader")) {
                 headers = Utils.constructConnectionHeadersMap(invokeConnectionRequest.getRequestHeaders());
             }
-            if (!headers.containsKey("x-skyflow-authorization")) {
-                headers.put("x-skyflow-authorization", token == null ? apiKey : token);
+            if (!headers.containsKey(Constants.SDK_AUTH_HEADER_KEY)) {
+                headers.put(Constants.SDK_AUTH_HEADER_KEY, token == null ? apiKey : token);
+                headers.put(Constants.SDK_METRICS_HEADER_KEY, Utils.getMetrics().toString());
             }
 
             RequestMethod requestMethod = invokeConnectionRequest.getMethod();

--- a/src/main/java/com/skyflow/vault/data/DeleteResponse.java
+++ b/src/main/java/com/skyflow/vault/data/DeleteResponse.java
@@ -1,5 +1,10 @@
 package com.skyflow.vault.data;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import java.util.ArrayList;
 
 public class DeleteResponse {
@@ -15,20 +20,9 @@ public class DeleteResponse {
 
     @Override
     public String toString() {
-        StringBuilder response = new StringBuilder("{");
-        response.append("\n\t\"deletedIds\": ").append(formatIds());
-        return response.append("\n}").toString();
-    }
-
-    private String formatIds() {
-        StringBuilder sb = new StringBuilder("[");
-        for (String id : deletedIds) {
-            sb.append("\n\t\"").append(id).append("\"");
-        }
-        return toIndentedString(sb.append("]"));
-    }
-
-    private String toIndentedString(Object o) {
-        return o.toString().replace("\n", "\n\t");
+        Gson gson = new Gson();
+        JsonObject responseObject = JsonParser.parseString(gson.toJson(this)).getAsJsonObject();
+        responseObject.add("errors", new JsonArray());
+        return responseObject.toString();
     }
 }

--- a/src/main/java/com/skyflow/vault/data/GetResponse.java
+++ b/src/main/java/com/skyflow/vault/data/GetResponse.java
@@ -1,5 +1,7 @@
 package com.skyflow.vault.data;
 
+import com.google.gson.Gson;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -22,30 +24,7 @@ public class GetResponse {
 
     @Override
     public String toString() {
-        StringBuilder response = new StringBuilder("{");
-        response.append("\n\t\"data\": ").append(formatRecords(data));
-        response.append(",\n\t\"errors\": ").append(formatRecords(errors));
-        response.append("\n}");
-        return response.toString();
-    }
-
-    private String formatRecords(ArrayList<HashMap<String, Object>> records) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int index = 0; index < records.size(); index++) {
-            HashMap<String, Object> map = records.get(index);
-            sb.append("{");
-            for (String key : map.keySet()) {
-                sb.append("\n\t\"").append(key).append("\": \"").append(map.get(key)).append("\",");
-            }
-            sb.append("\n}");
-            if (index != records.size() - 1) {
-                sb.append(", ");
-            }
-        }
-        return toIndentedString(sb.append("]"));
-    }
-
-    private String toIndentedString(Object o) {
-        return o.toString().replace("\n", "\n\t");
+        Gson gson = new Gson();
+        return gson.toJson(this);
     }
 }

--- a/src/main/java/com/skyflow/vault/data/InsertResponse.java
+++ b/src/main/java/com/skyflow/vault/data/InsertResponse.java
@@ -1,51 +1,30 @@
 package com.skyflow.vault.data;
 
+import com.google.gson.Gson;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 
 public class InsertResponse {
     private final ArrayList<HashMap<String, Object>> insertedFields;
-    private final ArrayList<HashMap<String, Object>> errorFields;
+    private final ArrayList<HashMap<String, Object>> errors;
 
-    public InsertResponse(ArrayList<HashMap<String, Object>> insertedFields, ArrayList<HashMap<String, Object>> errorFields) {
+    public InsertResponse(ArrayList<HashMap<String, Object>> insertedFields, ArrayList<HashMap<String, Object>> errors) {
         this.insertedFields = insertedFields;
-        this.errorFields = errorFields;
+        this.errors = errors;
     }
 
     public ArrayList<HashMap<String, Object>> getInsertedFields() {
         return insertedFields;
     }
 
-    public ArrayList<HashMap<String, Object>> getErrorFields() {
-        return errorFields;
+    public ArrayList<HashMap<String, Object>> getErrors() {
+        return errors;
     }
 
     @Override
     public String toString() {
-        StringBuilder response = new StringBuilder("{");
-        response.append("\n\t\"insertedFields\": ").append(formatRecords(insertedFields));
-        response.append(",\n\t\"errors\": ").append(formatRecords(errorFields));
-        response.append("\n}");
-        return response.toString();
-    }
-
-    private String formatRecords(ArrayList<HashMap<String, Object>> records) {
-        StringBuilder sb = new StringBuilder("[");
-        for (int index = 0; index < records.size(); index++) {
-            HashMap<String, Object> map = records.get(index);
-            sb.append("{");
-            for (String key : map.keySet()) {
-                sb.append("\n\t\"").append(key).append("\": \"").append(map.get(key)).append("\",");
-            }
-            sb.append("\n}");
-            if (index != records.size() - 1) {
-                sb.append(", ");
-            }
-        }
-        return toIndentedString(sb.append("]"));
-    }
-
-    private String toIndentedString(Object o) {
-        return o.toString().replace("\n", "\n\t");
+        Gson gson = new Gson();
+        return gson.toJson(this);
     }
 }

--- a/src/main/java/com/skyflow/vault/data/QueryResponse.java
+++ b/src/main/java/com/skyflow/vault/data/QueryResponse.java
@@ -1,5 +1,7 @@
 package com.skyflow.vault.data;
 
+import com.google.gson.*;
+
 import java.util.ArrayList;
 import java.util.HashMap;
 
@@ -17,30 +19,13 @@ public class QueryResponse {
 
     @Override
     public String toString() {
-        StringBuilder response = new StringBuilder("{");
-        response.append("\n\t\"fields\": ").append(formatFields());
-        return response.append("\n}").toString();
-    }
-
-    private String formatFields() {
-        StringBuilder sb = new StringBuilder("[");
-        for (int index = 0; index < fields.size(); index++) {
-            HashMap<String, Object> map = fields.get(index);
-            sb.append("{");
-            for (String key : map.keySet()) {
-                sb.append("\n\t\"").append(key).append("\": \"").append(map.get(key)).append("\",");
-            }
-            sb.append("\n\t\"tokenizedData\": ").append(tokenizedData);
-            sb.append("\n}");
-            if (index != fields.size() - 1) {
-                sb.append(", ");
-            }
+        Gson gson = new Gson();
+        JsonObject responseObject = JsonParser.parseString(gson.toJson(this)).getAsJsonObject();
+        JsonArray fieldsArray = responseObject.get("fields").getAsJsonArray();
+        for (JsonElement fieldElement : fieldsArray) {
+            fieldElement.getAsJsonObject().add("tokenizedData", null);
         }
-        return toIndentedString(sb.append("]"));
+        responseObject.add("errors", new JsonArray());
+        return responseObject.toString();
     }
-
-    private String toIndentedString(Object o) {
-        return o.toString().replace("\n", "\n\t");
-    }
-
 }

--- a/src/main/java/com/skyflow/vault/data/UpdateResponse.java
+++ b/src/main/java/com/skyflow/vault/data/UpdateResponse.java
@@ -1,5 +1,9 @@
 package com.skyflow.vault.data;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import java.util.HashMap;
 
 public class UpdateResponse {
@@ -21,20 +25,13 @@ public class UpdateResponse {
 
     @Override
     public String toString() {
-        StringBuilder response = new StringBuilder("{");
-        response.append("\n\t\"skyflowId\": \"").append(skyflowId).append("\"");
-        if (!tokens.isEmpty()) {
-            response.append(formatTokens(tokens));
+        Gson gson = new Gson();
+        JsonObject responseObject = JsonParser.parseString(gson.toJson(this)).getAsJsonObject();
+        responseObject.add("skyflow_id", responseObject.remove("skyflowId"));
+        JsonObject tokensObject = responseObject.remove("tokens").getAsJsonObject();
+        for (String key : tokensObject.keySet()) {
+            responseObject.add(key, tokensObject.get(key));
         }
-        response.append("\n}");
-        return response.toString();
-    }
-
-    private String formatTokens(HashMap<String, Object> tokens) {
-        StringBuilder sb = new StringBuilder();
-        for (String key : tokens.keySet()) {
-            sb.append("\n\t\"").append(key).append("\": \"").append(tokens.get(key)).append("\",");
-        }
-        return sb.toString();
+        return responseObject.toString();
     }
 }

--- a/src/main/java/com/skyflow/vault/tokens/DetokenizeRecordResponse.java
+++ b/src/main/java/com/skyflow/vault/tokens/DetokenizeRecordResponse.java
@@ -10,8 +10,8 @@ public class DetokenizeRecordResponse {
 
     public DetokenizeRecordResponse(V1DetokenizeRecordResponse record) {
         this.token = record.getToken();
-        this.value = record.getValue();
-        this.type = record.getValueType().getValue();
+        this.value = record.getValue().isEmpty() ? null : record.getValue();
+        this.type = record.getValueType().getValue().equals("NONE") ? null : record.getValueType().getValue();
         this.error = record.getError();
     }
 
@@ -29,19 +29,5 @@ public class DetokenizeRecordResponse {
 
     public String getType() {
         return type;
-    }
-
-    @Override
-    public String toString() {
-        StringBuilder response = new StringBuilder("{");
-        response.append("\n\t").append("\"token\": \"").append(token).append("\",");
-        if (error == null) {
-            response.append("\n\t").append("\"value\": \"").append(value).append("\",");
-            response.append("\n\t").append("\"type\": \"").append(type).append("\",");
-        } else {
-            response.append("\n\t").append("\"error\": \"").append(error).append("\",");
-        }
-        response.append("\n}");
-        return response.toString();
     }
 }

--- a/src/main/java/com/skyflow/vault/tokens/DetokenizeResponse.java
+++ b/src/main/java/com/skyflow/vault/tokens/DetokenizeResponse.java
@@ -1,14 +1,16 @@
 package com.skyflow.vault.tokens;
 
+import com.google.gson.Gson;
+
 import java.util.ArrayList;
 
 public class DetokenizeResponse {
     private final ArrayList<DetokenizeRecordResponse> detokenizedFields;
-    private final ArrayList<DetokenizeRecordResponse> errorRecords;
+    private final ArrayList<DetokenizeRecordResponse> errors;
 
-    public DetokenizeResponse(ArrayList<DetokenizeRecordResponse> detokenizedFields, ArrayList<DetokenizeRecordResponse> errorRecords) {
+    public DetokenizeResponse(ArrayList<DetokenizeRecordResponse> detokenizedFields, ArrayList<DetokenizeRecordResponse> errors) {
         this.detokenizedFields = detokenizedFields;
-        this.errorRecords = errorRecords;
+        this.errors = errors;
     }
 
     public ArrayList<DetokenizeRecordResponse> getDetokenizedFields() {
@@ -16,19 +18,12 @@ public class DetokenizeResponse {
     }
 
     public ArrayList<DetokenizeRecordResponse> getErrors() {
-        return errorRecords;
+        return errors;
     }
 
     @Override
     public String toString() {
-        StringBuilder response = new StringBuilder("{");
-        response.append("\n\t").append("\"detokenizedFields\": ").append(toIndentedString(detokenizedFields));
-        response.append("\n\t").append("\"errors\": ").append(toIndentedString(errorRecords));
-        response.append("\n}");
-        return response.toString();
-    }
-
-    private String toIndentedString(Object o) {
-        return o.toString().replace("\n", "\n\t");
+        Gson gson = new Gson();
+        return gson.toJson(this);
     }
 }

--- a/src/main/java/com/skyflow/vault/tokens/TokenizeResponse.java
+++ b/src/main/java/com/skyflow/vault/tokens/TokenizeResponse.java
@@ -1,5 +1,10 @@
 package com.skyflow.vault.tokens;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
+
 import java.util.List;
 
 public class TokenizeResponse {
@@ -15,8 +20,9 @@ public class TokenizeResponse {
 
     @Override
     public String toString() {
-        StringBuilder response = new StringBuilder("{");
-        response.append("\n\t\"tokens\": ").append(tokens);
-        return response.append("\n}").toString();
+        Gson gson = new Gson();
+        JsonObject responseObject = JsonParser.parseString(gson.toJson(this)).getAsJsonObject();
+        responseObject.add("errors", new JsonArray());
+        return responseObject.toString();
     }
 }

--- a/src/test/java/com/skyflow/SkyflowTests.java
+++ b/src/test/java/com/skyflow/SkyflowTests.java
@@ -140,8 +140,6 @@ public class SkyflowTests {
             Credentials credentials = new Credentials();
             credentials.setToken(token);
 
-            skyflowClient.updateVaultConfig(config);
-
             config.setClusterId(newClusterID);
             config.setEnv(Env.PROD);
             config.setCredentials(credentials);

--- a/src/test/java/com/skyflow/utils/UtilsTests.java
+++ b/src/test/java/com/skyflow/utils/UtilsTests.java
@@ -1,5 +1,6 @@
 package com.skyflow.utils;
 
+import com.google.gson.JsonObject;
 import com.skyflow.config.ConnectionConfig;
 import com.skyflow.config.Credentials;
 import com.skyflow.enums.Env;
@@ -177,6 +178,37 @@ public class UtilsTests {
             Assert.assertTrue(headers.containsKey("header"));
             Assert.assertFalse(headers.containsKey("HEADER"));
             Assert.assertEquals("value", headers.get("header"));
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testGetMetrics() {
+        try {
+            JsonObject metrics = Utils.getMetrics();
+            Assert.assertNotNull(metrics.get(Constants.SDK_METRIC_NAME_VERSION));
+            Assert.assertNotNull(metrics.get(Constants.SDK_METRIC_CLIENT_DEVICE_MODEL));
+            Assert.assertNotNull(metrics.get(Constants.SDK_METRIC_CLIENT_OS_DETAILS));
+            Assert.assertNotNull(metrics.get(Constants.SDK_METRIC_RUNTIME_DETAILS));
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testGetMetricsWithException() {
+        try {
+            // Clearing System Properties explicitly to throw exception
+            System.clearProperty("os.name");
+            System.clearProperty("os.version");
+            System.clearProperty("java.version");
+
+            JsonObject metrics = Utils.getMetrics();
+            Assert.assertEquals("skyflow-java@v2", metrics.get(Constants.SDK_METRIC_NAME_VERSION).getAsString());
+            Assert.assertEquals("Java@", metrics.get(Constants.SDK_METRIC_RUNTIME_DETAILS).getAsString());
+            Assert.assertTrue(metrics.get(Constants.SDK_METRIC_CLIENT_DEVICE_MODEL).getAsString().isEmpty());
+            Assert.assertTrue(metrics.get(Constants.SDK_METRIC_CLIENT_OS_DETAILS).getAsString().isEmpty());
         } catch (Exception e) {
             Assert.fail(INVALID_EXCEPTION_THROWN);
         }

--- a/src/test/java/com/skyflow/vault/connection/InvokeConnectionTests.java
+++ b/src/test/java/com/skyflow/vault/connection/InvokeConnectionTests.java
@@ -400,8 +400,8 @@ public class InvokeConnectionTests {
             responseObject.addProperty("test_key_1", "test_value_1");
             responseObject.addProperty("test_key_2", "test_value_2");
             InvokeConnectionResponse connectionResponse = new InvokeConnectionResponse(responseObject);
-            String responseString = "InvokeConnectionResponse{" + "response=" + responseObject + "}";
-            Assert.assertEquals(responseString, connectionResponse.toString());
+            Assert.assertEquals(2, connectionResponse.getResponse().size());
+            Assert.assertEquals(responseObject.toString(), connectionResponse.toString());
         } catch (Exception e) {
             Assert.fail(INVALID_EXCEPTION_THROWN);
         }

--- a/src/test/java/com/skyflow/vault/data/DeleteTests.java
+++ b/src/test/java/com/skyflow/vault/data/DeleteTests.java
@@ -149,7 +149,7 @@ public class DeleteTests {
         try {
             ids.add(skyflowID);
             DeleteResponse response = new DeleteResponse(ids);
-            String responseString = "{\n\t\"deletedIds\": [\n\t\t\"" + skyflowID + "\"]\n}";
+            String responseString = "{\"deletedIds\":[\"" + skyflowID + "\"],\"errors\":[]}";
             Assert.assertEquals(1, response.getDeletedIds().size());
             Assert.assertEquals(responseString, response.toString());
         } catch (Exception e) {

--- a/src/test/java/com/skyflow/vault/data/GetTests.java
+++ b/src/test/java/com/skyflow/vault/data/GetTests.java
@@ -471,12 +471,12 @@ public class GetTests {
             data.add(record);
             ArrayList<HashMap<String, Object>> errors = new ArrayList<>();
             GetResponse response = new GetResponse(data, errors);
-            String responseString = "{\n\t\"data\": [" +
-                    "{\n\t\t\"test_column_1\": \"test_value_1\"," +
-                    "\n\t\t\"test_column_2\": \"test_value_2\",\n\t}, " +
-                    "{\n\t\t\"test_column_1\": \"test_value_1\"," +
-                    "\n\t\t\"test_column_2\": \"test_value_2\",\n\t}]" +
-                    ",\n\t\"errors\": " + errors + "\n}";
+            String responseString = "{\"data\":[" +
+                    "{\"test_column_1\":\"test_value_1\"," +
+                    "\"test_column_2\":\"test_value_2\"}," +
+                    "{\"test_column_1\":\"test_value_1\"," +
+                    "\"test_column_2\":\"test_value_2\"}]" +
+                    ",\"errors\":" + errors + "}";
             Assert.assertEquals(2, response.getData().size());
             Assert.assertTrue(response.getErrors().isEmpty());
             Assert.assertEquals(responseString, response.toString());

--- a/src/test/java/com/skyflow/vault/data/InsertTests.java
+++ b/src/test/java/com/skyflow/vault/data/InsertTests.java
@@ -384,14 +384,14 @@ public class InsertTests {
             values.add(valueMap);
             values.add(valueMap);
             InsertResponse response = new InsertResponse(values, errorFields);
-            String responseString = "{\n\t\"insertedFields\": [" +
-                    "{\n\t\t\"test_column_1\": \"test_value_1\"," +
-                    "\n\t\t\"test_column_2\": \"test_value_2\",\n\t}, " +
-                    "{\n\t\t\"test_column_1\": \"test_value_1\"," +
-                    "\n\t\t\"test_column_2\": \"test_value_2\",\n\t}]" +
-                    ",\n\t\"errors\": " + errorFields + "\n}";
+            String responseString = "{\"insertedFields\":[" +
+                    "{\"test_column_1\":\"test_value_1\"," +
+                    "\"test_column_2\":\"test_value_2\"}," +
+                    "{\"test_column_1\":\"test_value_1\"," +
+                    "\"test_column_2\":\"test_value_2\"}]" +
+                    ",\"errors\":" + errorFields + "}";
             Assert.assertEquals(2, response.getInsertedFields().size());
-            Assert.assertTrue(response.getErrorFields().isEmpty());
+            Assert.assertTrue(response.getErrors().isEmpty());
             Assert.assertEquals(responseString, response.toString());
         } catch (Exception e) {
             Assert.fail(INVALID_EXCEPTION_THROWN);

--- a/src/test/java/com/skyflow/vault/data/QueryTests.java
+++ b/src/test/java/com/skyflow/vault/data/QueryTests.java
@@ -94,11 +94,10 @@ public class QueryTests {
             fields.add(queryRecord);
             fields.add(queryRecord);
             QueryResponse response = new QueryResponse(fields);
-            String responseString = "{\n\t\"fields\": " +
-                    "[{\n\t\t\"card_number\": \"test_card_number\",\n\t\t\"name\": \"test_name\"," +
-                    "\n\t\t\"tokenizedData\": " + null + "\n\t}, " +
-                    "{\n\t\t\"card_number\": \"test_card_number\",\n\t\t\"name\": \"test_name\"," +
-                    "\n\t\t\"tokenizedData\": " + null + "\n\t}]\n}";
+            String responseString = "{\"fields\":" +
+                    "[{\"card_number\":\"test_card_number\",\"name\":\"test_name\",\"tokenizedData\":null}," +
+                    "{\"card_number\":\"test_card_number\",\"name\":\"test_name\",\"tokenizedData\":null}]," +
+                    "\"errors\":[]}";
             Assert.assertEquals(2, response.getFields().size());
             Assert.assertEquals(responseString, response.toString());
         } catch (Exception e) {

--- a/src/test/java/com/skyflow/vault/data/UpdateTests.java
+++ b/src/test/java/com/skyflow/vault/data/UpdateTests.java
@@ -386,9 +386,9 @@ public class UpdateTests {
             tokenMap.put("test_column_1", "test_token_1");
             tokenMap.put("test_column_2", "test_token_2");
             UpdateResponse response = new UpdateResponse(skyflowID, tokenMap);
-            String responseString = "{\n\t\"skyflowId\": \"" + skyflowID + "\""
-                    + "\n\t\"test_column_1\": \"test_token_1\","
-                    + "\n\t\"test_column_2\": \"test_token_2\",\n}";
+            String responseString = "{\"skyflow_id\":\"" + skyflowID + "\","
+                    + "\"test_column_1\":\"test_token_1\","
+                    + "\"test_column_2\":\"test_token_2\"}";
             Assert.assertEquals(skyflowID, response.getSkyflowId());
             Assert.assertEquals(2, response.getTokens().size());
             Assert.assertEquals(responseString, response.toString());

--- a/src/test/java/com/skyflow/vault/tokens/DetokenizeTests.java
+++ b/src/test/java/com/skyflow/vault/tokens/DetokenizeTests.java
@@ -126,6 +126,7 @@ public class DetokenizeTests {
 
             V1DetokenizeRecordResponse record2 = new V1DetokenizeRecordResponse();
             record2.setToken("3456-7890-1234-5678");
+            record2.setValue("");
             record2.setError("Invalid token");
             DetokenizeRecordResponse error = new DetokenizeRecordResponse(record2);
 
@@ -138,11 +139,11 @@ public class DetokenizeTests {
             errors.add(error);
 
             DetokenizeResponse response = new DetokenizeResponse(fields, errors);
-            String responseString = "{\n\t\"detokenizedFields\": [{" +
-                    "\n\t\t\"token\": \"1234-5678-9012-3456\",\n\t\t\"value\": \"4111111111111111\",\n\t\t\"type\": \"STRING\",\n\t}, " +
-                    "{\n\t\t\"token\": \"1234-5678-9012-3456\",\n\t\t\"value\": \"4111111111111111\",\n\t\t\"type\": \"STRING\",\n\t}]" +
-                    "\n\t\"errors\": [{\n\t\t\"token\": \"3456-7890-1234-5678\",\n\t\t\"error\": \"Invalid token\",\n\t}, " +
-                    "{\n\t\t\"token\": \"3456-7890-1234-5678\",\n\t\t\"error\": \"Invalid token\",\n\t}]\n}";
+            String responseString = "{\"detokenizedFields\":[{" +
+                    "\"token\":\"1234-5678-9012-3456\",\"value\":\"4111111111111111\",\"type\":\"STRING\"}," +
+                    "{\"token\":\"1234-5678-9012-3456\",\"value\":\"4111111111111111\",\"type\":\"STRING\"}]," +
+                    "\"errors\":[{\"token\":\"3456-7890-1234-5678\",\"error\":\"Invalid token\"}," +
+                    "{\"token\":\"3456-7890-1234-5678\",\"error\":\"Invalid token\"}]}";
             Assert.assertEquals(2, response.getDetokenizedFields().size());
             Assert.assertEquals(2, response.getErrors().size());
             Assert.assertEquals("1234-5678-9012-3456", response.getDetokenizedFields().get(0).getToken());

--- a/src/test/java/com/skyflow/vault/tokens/TokenizeTests.java
+++ b/src/test/java/com/skyflow/vault/tokens/TokenizeTests.java
@@ -129,7 +129,7 @@ public class TokenizeTests {
             tokens.add("1234-5678-9012-3456");
             tokens.add("5678-9012-3456-7890");
             TokenizeResponse response = new TokenizeResponse(tokens);
-            String responseString = "{\n\t\"tokens\": [1234-5678-9012-3456, 5678-9012-3456-7890]\n}";
+            String responseString = "{\"tokens\":[\"1234-5678-9012-3456\",\"5678-9012-3456-7890\"],\"errors\":[]}";
             Assert.assertEquals(2, response.getTokens().size());
             Assert.assertEquals(responseString, response.toString());
         } catch (Exception e) {


### PR DESCRIPTION
This PR includes changes in the way we are parsing the responses of API requests. It also fixes few inconsistencies w.r.t other server-side SDKs along with few additional unit tests.

## Why
- Java SDK v2 has some inconsistencies that needs to be addressed.
- Change in response parsing for API requests.
- To ensure consistent behaviour across server-side SDKs.

## Goal
- Fewer inconsistencies w.r.t other server-side SDKs.
- Improved response parsing for API requests. 

## Testing
- Manual testing for all vault API interfaces along with connections.
- Additional unit tests for fixed inconsistencies.
