### PR TITLE
SK-1737 Fix inconsistencies in Java SDK

### DIFF
--- a/src/main/java/com/skyflow/Skyflow.java
+++ b/src/main/java/com/skyflow/Skyflow.java
@@ -82,13 +82,23 @@ public final class Skyflow {
         return this.builder.logLevel;
     }
 
-    public VaultController vault() {
-        String vaultId = (String) this.builder.vaultClientsMap.keySet().toArray()[0];
+    public VaultController vault() throws SkyflowException {
+        Object[] array = this.builder.vaultClientsMap.keySet().toArray();
+        if (array.length < 1) {
+            LogUtil.printErrorLog(ErrorLogs.VAULT_CONFIG_DOES_NOT_EXIST.getLog());
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.VaultIdNotInConfigList.getMessage());
+        }
+        String vaultId = (String) array[0];
         return this.vault(vaultId);
     }
 
-    public VaultController vault(String vaultId) {
-        return this.builder.vaultClientsMap.get(vaultId);
+    public VaultController vault(String vaultId) throws SkyflowException {
+        VaultController controller = this.builder.vaultClientsMap.get(vaultId);
+        if (controller == null) {
+            LogUtil.printErrorLog(ErrorLogs.VAULT_CONFIG_DOES_NOT_EXIST.getLog());
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.VaultIdNotInConfigList.getMessage());
+        }
+        return controller;
     }
 
     public ConnectionController connection() {

--- a/src/main/java/com/skyflow/utils/HttpUtility.java
+++ b/src/main/java/com/skyflow/utils/HttpUtility.java
@@ -13,13 +13,12 @@ import java.util.Map;
 
 public final class HttpUtility {
 
+    private static final String LINE_FEED = "\r\n";
     private static String requestID;
 
     public static String getRequestID() {
         return requestID;
     }
-
-    private static final String LINE_FEED = "\r\n";
 
     public static String sendRequest(String method, URL url, JsonObject params, Map<String, String> headers) throws IOException, SkyflowException {
 
@@ -55,7 +54,7 @@ public final class HttpUtility {
                         input = formatJsonToFormEncodedString(params).getBytes(StandardCharsets.UTF_8);
                     } else if (requestContentType.contains("multipart/form-data")) {
                         input = formatJsonToMultiPartFormDataString(params, boundary).getBytes(StandardCharsets.UTF_8);
-                    }else {
+                    } else {
                         input = params.toString().getBytes(StandardCharsets.UTF_8);
                     }
 
@@ -66,7 +65,7 @@ public final class HttpUtility {
 
             int status = connection.getResponseCode();
             String requestID = connection.getHeaderField("x-request-id");
-            HttpUtility.requestID = requestID;
+            HttpUtility.requestID = requestID.split(",")[0];
 
             Reader streamReader;
             if (status > 299) {

--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -1,5 +1,7 @@
 package com.skyflow.utils.validations;
 
+import com.google.gson.Gson;
+import com.google.gson.JsonObject;
 import com.skyflow.config.ConnectionConfig;
 import com.skyflow.config.Credentials;
 import com.skyflow.config.VaultConfig;
@@ -132,8 +134,9 @@ public class Validations {
         }
 
         if (requestBody != null) {
-            Map<String, String> requestBodyMap = (Map<String, String>) requestBody;
-            if (requestBodyMap.isEmpty()) {
+            Gson gson = new Gson();
+            JsonObject bodyObject = gson.toJsonTree(requestBody).getAsJsonObject();
+            if (bodyObject.isEmpty()) {
                 LogUtil.printErrorLog(Utils.parameterizedString(
                         ErrorLogs.EMPTY_REQUEST_BODY.getLog(), InterfaceName.INVOKE_CONNECTION.getName()));
                 throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyRequestBody.getMessage());

--- a/src/main/java/com/skyflow/vault/connection/InvokeConnectionResponse.java
+++ b/src/main/java/com/skyflow/vault/connection/InvokeConnectionResponse.java
@@ -1,25 +1,29 @@
 package com.skyflow.vault.connection;
 
 import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
 import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
 
 public class InvokeConnectionResponse {
-    private JsonObject response;
+    private final JsonObject data;
+    private final JsonObject metadata;
 
-    public InvokeConnectionResponse(JsonObject response) {
-        this.response = response;
+    public InvokeConnectionResponse(JsonObject data, JsonObject metadata) {
+        this.data = data;
+        this.metadata = metadata;
     }
 
-    public JsonObject getResponse() {
-        return response;
+    public JsonObject getData() {
+        return data;
+    }
+
+    public JsonObject getMetadata() {
+        return metadata;
     }
 
     @Override
     public String toString() {
-        Gson gson = new Gson();
-        JsonObject responseObject = JsonParser.parseString(gson.toJson(this)).getAsJsonObject();
-        responseObject = responseObject.remove("response").getAsJsonObject();
-        return responseObject.toString();
+        Gson gson = new GsonBuilder().serializeNulls().create();
+        return gson.toJson(this);
     }
 }

--- a/src/main/java/com/skyflow/vault/controller/ConnectionController.java
+++ b/src/main/java/com/skyflow/vault/controller/ConnectionController.java
@@ -64,7 +64,10 @@ public class ConnectionController extends ConnectionClient {
             }
 
             String response = HttpUtility.sendRequest(requestMethod.name(), new URL(filledURL), requestBody, headers);
-            connectionResponse = new InvokeConnectionResponse((JsonObject) JsonParser.parseString(response));
+            JsonObject data = JsonParser.parseString(response).getAsJsonObject();
+            JsonObject metadata = new JsonObject();
+            metadata.addProperty("requestId", HttpUtility.getRequestID());
+            connectionResponse = new InvokeConnectionResponse(data, metadata);
             LogUtil.printInfoLog(InfoLogs.INVOKE_CONNECTION_REQUEST_RESOLVED.getLog());
         } catch (IOException e) {
             LogUtil.printErrorLog(ErrorLogs.INVOKE_CONNECTION_REQUEST_REJECTED.getLog());

--- a/src/test/java/com/skyflow/SkyflowTests.java
+++ b/src/test/java/com/skyflow/SkyflowTests.java
@@ -198,6 +198,40 @@ public class SkyflowTests {
         }
     }
 
+    @Test
+    public void testGettingAlreadyRemovedVaultFromEmptyConfigs() {
+        try {
+            Skyflow skyflowClient = Skyflow.builder().build();
+            skyflowClient.vault();
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(ErrorMessage.VaultIdNotInConfigList.getMessage(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testGettingAlreadyRemovedVaultFromNonEmptyConfigs() {
+        try {
+            VaultConfig primaryConfig = new VaultConfig();
+            primaryConfig.setVaultId(vaultID);
+            primaryConfig.setClusterId(clusterID);
+            primaryConfig.setEnv(Env.SANDBOX);
+
+            VaultConfig secondaryConfig = new VaultConfig();
+            secondaryConfig.setVaultId(vaultID + "123");
+            secondaryConfig.setClusterId(clusterID);
+            secondaryConfig.setEnv(Env.SANDBOX);
+            Skyflow skyflowClient = Skyflow.builder().addVaultConfig(primaryConfig).addVaultConfig(secondaryConfig).build();
+            skyflowClient.removeVaultConfig(vaultID);
+            skyflowClient.vault(vaultID);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(ErrorMessage.VaultIdNotInConfigList.getMessage(), e.getMessage());
+        }
+    }
+
 
     @Test
     public void testAddingInvalidConnectionConfigInSkyflowBuilder() {

--- a/src/test/java/com/skyflow/vault/connection/InvokeConnectionTests.java
+++ b/src/test/java/com/skyflow/vault/connection/InvokeConnectionTests.java
@@ -420,12 +420,17 @@ public class InvokeConnectionTests {
     @Test
     public void testInvokeConnectionResponse() {
         try {
-            JsonObject responseObject = new JsonObject();
-            responseObject.addProperty("test_key_1", "test_value_1");
-            responseObject.addProperty("test_key_2", "test_value_2");
-            InvokeConnectionResponse connectionResponse = new InvokeConnectionResponse(responseObject);
-            Assert.assertEquals(2, connectionResponse.getResponse().size());
-            Assert.assertEquals(responseObject.toString(), connectionResponse.toString());
+            JsonObject data = new JsonObject();
+            data.addProperty("test_key_1", "test_value_1");
+            data.addProperty("test_key_2", "test_value_2");
+            JsonObject metadata = new JsonObject();
+            metadata.addProperty("requestId", "12345");
+            InvokeConnectionResponse connectionResponse = new InvokeConnectionResponse(data, metadata);
+            String responseString = "{\"data\":{\"test_key_1\":\"test_value_1\",\"test_key_2\":\"test_value_2\"}," +
+                    "\"metadata\":{\"requestId\":\"12345\"}}";
+            Assert.assertEquals(2, connectionResponse.getData().size());
+            Assert.assertEquals(responseString, connectionResponse.toString());
+            Assert.assertEquals(1, connectionResponse.getMetadata().size());
         } catch (Exception e) {
             Assert.fail(INVALID_EXCEPTION_THROWN);
         }

--- a/src/test/java/com/skyflow/vault/controller/ConnectionControllerTests.java
+++ b/src/test/java/com/skyflow/vault/controller/ConnectionControllerTests.java
@@ -39,7 +39,7 @@ public class ConnectionControllerTests {
     @Test
     public void testInvalidRequestInInvokeConnectionMethod() {
         try {
-            HashMap<String,String> requestBody = new HashMap<>();
+            HashMap<String, String> requestBody = new HashMap<>();
             InvokeConnectionRequest connectionRequest = InvokeConnectionRequest.builder().requestBody(requestBody).build();
             Skyflow skyflowClient = Skyflow.builder().setLogLevel(LogLevel.DEBUG).addConnectionConfig(connectionConfig).build();
             skyflowClient.connection().invoke(connectionRequest);


### PR DESCRIPTION
This PR includes changes to fix inconsistencies with respect to other server-side SDKs, some missing validation scenario along with additional unit tests.

### Why
- Java SDK v2 has some inconsistencies that needs to be addressed.
- To ensure consistent behaviour across server-side SDKs.

### Goal
- Fewer inconsistencies w.r.t other server-side SDKs. 
- Consistent response structure for invoke connection response.

### Testing
- Manual testing for all vault API interfaces along with connections.
- Additional unit tests for fixed inconsistencies.
