### PR TITLE
SK-1633 Run Endor labs scan to identify security vulnerabilities

### DIFF
--- a/.github/workflows/endorlabsScan.yml
+++ b/.github/workflows/endorlabsScan.yml
@@ -1,0 +1,40 @@
+name: Endor Labs Scan Java Project
+
+on:
+  workflow_dispatch:
+    inputs:
+      java_version:
+        description: "The version of Java to be used for build"
+        default: "1.8"
+        required: true
+
+jobs:
+  clone-build-scan:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: zulu
+          java-version: ${{ github.event.inputs.java_version }}
+
+      - name: Create env
+        id: create-env
+        run: |
+          touch .env
+          echo SKYFLOW_CREDENTIALS=${{ secrets.SKYFLOW_CREDENTIALS }} >> .env
+          echo TEST_EXPIRED_TOKEN=${{ secrets.TEST_EXPIRED_TOKEN }} >> .env
+          echo TEST_REUSABLE_TOKEN=${{ secrets.TEST_REUSABLE_TOKEN }} >> .env
+
+      - name: Compile Package
+        run: mvn clean install
+
+      - name: Endor Labs SCA Scan
+        uses: endorlabs/github-action@main
+        with:
+          namespace: "skyflow"
+          api: "https://api.endorlabs.com"
+          pr: false
+          enable_github_action_token: true
+          scan_dependencies: true
+          additional_args: "--as-default-branch --call-graph-languages=java"


### PR DESCRIPTION
Added a workflow to trigger endor labs scan on skyflow-java repository.
## Why
- There is a need to monitor different branches in skyflow-java repository on endor labs.

## Goal
- To be able to monitor all branches of skyflow-java repository on endor labs
