### PR TITLE
SK-1633 Fix failure in endorlabs workflow

### DIFF
--- a/.github/workflows/endorlabsScan.yml
+++ b/.github/workflows/endorlabsScan.yml
@@ -26,6 +26,13 @@ jobs:
           echo TEST_EXPIRED_TOKEN=${{ secrets.TEST_EXPIRED_TOKEN }} >> .env
           echo TEST_REUSABLE_TOKEN=${{ secrets.TEST_REUSABLE_TOKEN }} >> .env
 
+      - name: create-json
+        id: create-json
+        uses: jsdaniell/create-json@1.1.2
+        with:
+          name: "credentials.json"
+          json: ${{ secrets.TEST_CREDENTIALS_FILE_STRING }}
+
       - name: Compile Package
         run: mvn clean install
 


### PR DESCRIPTION
Add a missing step to create `credentials.json` file in endor labs workflow
## Why
- The missing step caused some unit test failures while running the workflow.

## Goal
- Fix unit test failures due to missing step
