### PR TITLE
SK-1633 Add GPG secrets to endorlabs workflow

### DIFF
--- a/.github/workflows/endorlabsScan.yml
+++ b/.github/workflows/endorlabsScan.yml
@@ -17,6 +17,8 @@ jobs:
         with:
           distribution: zulu
           java-version: ${{ github.event.inputs.java_version }}
+          gpg-private-key: ${{ secrets.GPG_KEY }} # Value of the GPG private key to import
+          gpg-passphrase: ${{ secrets.GPG_PASSPHRASE }} # env variable for GPG private key passphrase
 
       - name: Create env
         id: create-env


### PR DESCRIPTION
Add GPG secrets to `endorlabsScan.yml` workflow.
## Why
- Due to missing gpg secrets, the workflow was failing in CI pipeline.

## Goal
- Fix failures in workflow run 
