### PR TITLE
SK-1633 Add permissions for endorlabs scan

### DIFF
--- a/.github/workflows/endorlabsScan.yml
+++ b/.github/workflows/endorlabsScan.yml
@@ -11,6 +11,9 @@ on:
 jobs:
   build-and-scan:
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-java@v4


### PR DESCRIPTION
Added permissions for endrolabs to scan the repo
## Why
- The workflow for endorlabs scan was failing. 

## Goal
- To fix the failure in `endorlabsScan.yml` workflow
