### PR TITLE
SK-1829 Fix http status for validation errors in Java SDK v2

### DIFF
--- a/src/main/java/com/skyflow/errors/HttpStatus.java
+++ b/src/main/java/com/skyflow/errors/HttpStatus.java
@@ -1,0 +1,15 @@
+package com.skyflow.errors;
+
+public enum HttpStatus {
+    BAD_REQUEST("Bad Request");
+
+    private final String httpStatus;
+
+    HttpStatus(String httpStatus) {
+        this.httpStatus = httpStatus;
+    }
+
+    public String getHttpStatus() {
+        return httpStatus;
+    }
+}

--- a/src/main/java/com/skyflow/errors/SkyflowException.java
+++ b/src/main/java/com/skyflow/errors/SkyflowException.java
@@ -37,6 +37,8 @@ public class SkyflowException extends Exception {
         super(message);
         this.httpCode = code;
         this.message = message;
+        this.httpStatus = HttpStatus.BAD_REQUEST.getHttpStatus();
+        this.details = new JsonArray();
     }
 
     public SkyflowException(int httpCode, Throwable cause, Map<String, List<String>> responseHeaders, String responseBody) {

--- a/src/main/java/com/skyflow/errors/SkyflowException.java
+++ b/src/main/java/com/skyflow/errors/SkyflowException.java
@@ -1,13 +1,9 @@
 package com.skyflow.errors;
 
-import com.google.gson.JsonArray;
-import com.google.gson.JsonObject;
-import com.google.gson.JsonParser;
-import com.google.gson.JsonSyntaxException;
+import com.google.gson.*;
 
 import java.util.List;
 import java.util.Map;
-import java.util.Objects;
 
 public class SkyflowException extends Exception {
     private String requestId;
@@ -42,25 +38,22 @@ public class SkyflowException extends Exception {
     }
 
     public SkyflowException(int httpCode, Throwable cause, Map<String, List<String>> responseHeaders, String responseBody) {
-        this(cause);
+        super(cause);
         this.httpCode = httpCode;
-        String contentType = responseHeaders.get("content-type").get(0);
         setRequestId(responseHeaders);
-        if (Objects.equals(contentType, "application/json")) {
-            setResponseBody(responseBody);
-        } else if (Objects.equals(contentType, "text/plain")) {
-            this.message = responseBody;
-        }
+        setResponseBody(responseBody);
     }
 
     private void setResponseBody(String responseBody) {
         try {
             if (responseBody != null) {
                 this.responseBody = JsonParser.parseString(responseBody).getAsJsonObject();
-                setGrpcCode();
-                setHttpStatus();
-                setMessage();
-                setDetails();
+                if (this.responseBody.get("error") != null) {
+                    setGrpcCode();
+                    setHttpStatus();
+                    setMessage();
+                    setDetails();
+                }
             }
         } catch (JsonSyntaxException e) {
             throw new RuntimeException(e);
@@ -74,24 +67,28 @@ public class SkyflowException extends Exception {
     private void setRequestId(Map<String, List<String>> responseHeaders) {
         if (responseHeaders != null) {
             List<String> ids = responseHeaders.get("x-request-id");
-            this.requestId = ids.get(0);
+            this.requestId = ids == null ? null : ids.get(0);
         }
     }
 
     private void setMessage() {
-        this.message = ((JsonObject) responseBody.get("error")).get("message").getAsString();
+        JsonElement messageElement = ((JsonObject) responseBody.get("error")).get("message");
+        this.message = messageElement == null ? null : messageElement.getAsString();
     }
 
     private void setGrpcCode() {
-        this.grpcCode = ((JsonObject) responseBody.get("error")).get("grpc_code").getAsInt();
+        JsonElement grpcElement = ((JsonObject) responseBody.get("error")).get("grpc_code");
+        this.grpcCode = grpcElement == null ? null : grpcElement.getAsInt();
     }
 
     private void setHttpStatus() {
-        this.httpStatus = ((JsonObject) responseBody.get("error")).get("http_status").getAsString();
+        JsonElement statusElement = ((JsonObject) responseBody.get("error")).get("http_status");
+        this.httpStatus = statusElement == null ? null : statusElement.getAsString();
     }
 
     private void setDetails() {
-        this.details = ((JsonObject) responseBody.get("error")).get("details").getAsJsonArray();
+        JsonElement detailsElement = ((JsonObject) responseBody.get("error")).get("details");
+        this.details = detailsElement == null ? null : detailsElement.getAsJsonArray();
     }
 
     public int getHttpCode() {

--- a/src/main/java/com/skyflow/vault/connection/InvokeConnectionResponse.java
+++ b/src/main/java/com/skyflow/vault/connection/InvokeConnectionResponse.java
@@ -2,22 +2,23 @@ package com.skyflow.vault.connection;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
-import com.google.gson.JsonObject;
+
+import java.util.HashMap;
 
 public class InvokeConnectionResponse {
-    private final JsonObject data;
-    private final JsonObject metadata;
+    private final Object data;
+    private final HashMap<String, String> metadata;
 
-    public InvokeConnectionResponse(JsonObject data, JsonObject metadata) {
+    public InvokeConnectionResponse(Object data, HashMap<String, String> metadata) {
         this.data = data;
         this.metadata = metadata;
     }
 
-    public JsonObject getData() {
+    public Object getData() {
         return data;
     }
 
-    public JsonObject getMetadata() {
+    public HashMap<String, String> getMetadata() {
         return metadata;
     }
 

--- a/src/main/java/com/skyflow/vault/controller/ConnectionController.java
+++ b/src/main/java/com/skyflow/vault/controller/ConnectionController.java
@@ -26,7 +26,7 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.Map;
 
-public class ConnectionController extends ConnectionClient {
+public final class ConnectionController extends ConnectionClient {
     public ConnectionController(ConnectionConfig connectionConfig, Credentials credentials) {
         super(connectionConfig, credentials);
     }
@@ -65,8 +65,8 @@ public class ConnectionController extends ConnectionClient {
 
             String response = HttpUtility.sendRequest(requestMethod.name(), new URL(filledURL), requestBody, headers);
             JsonObject data = JsonParser.parseString(response).getAsJsonObject();
-            JsonObject metadata = new JsonObject();
-            metadata.addProperty("requestId", HttpUtility.getRequestID());
+            HashMap<String, String> metadata = new HashMap<>();
+            metadata.put("requestId", HttpUtility.getRequestID());
             connectionResponse = new InvokeConnectionResponse(data, metadata);
             LogUtil.printInfoLog(InfoLogs.INVOKE_CONNECTION_REQUEST_RESOLVED.getLog());
         } catch (IOException e) {

--- a/src/test/java/com/skyflow/utils/HttpUtilityTests.java
+++ b/src/test/java/com/skyflow/utils/HttpUtilityTests.java
@@ -43,7 +43,7 @@ public class HttpUtilityTests {
     @Before
     public void setup() throws IOException {
         expected = "{\"status\":\"success\"}";
-        expectedError = "{\"status\":\"something went wrong\"}";
+        expectedError = "{\"error\":{\"grpc_code\":123,\"http_code\":500,\"message\":\"something went wrong\",\"http_status\":\"internal server error\",\"details\":[]}}\n";
         mockConnection = Mockito.mock(HttpURLConnection.class);
         given(mockConnection.getInputStream()).willReturn(new ByteArrayInputStream(expected.getBytes()));
         given(mockConnection.getErrorStream()).willReturn(new ByteArrayInputStream(expectedError.getBytes()));
@@ -115,7 +115,11 @@ public class HttpUtilityTests {
             given(mockConnection.getResponseCode()).willReturn(500);
             String response = httpUtility.sendRequest("GET", url, null, null);
         } catch (SkyflowException e) {
-            Assert.assertEquals(expectedError, e.getMessage());
+            Assert.assertEquals(500, e.getHttpCode());
+            Assert.assertEquals(new Integer(123), e.getGrpcCode());
+            Assert.assertEquals("internal server error", e.getHttpStatus());
+            Assert.assertEquals("something went wrong", e.getMessage());
+            Assert.assertTrue(e.getDetails().isEmpty());
         } catch (Exception e) {
             fail(INVALID_EXCEPTION_THROWN);
         }

--- a/src/test/java/com/skyflow/vault/connection/InvokeConnectionTests.java
+++ b/src/test/java/com/skyflow/vault/connection/InvokeConnectionTests.java
@@ -423,12 +423,12 @@ public class InvokeConnectionTests {
             JsonObject data = new JsonObject();
             data.addProperty("test_key_1", "test_value_1");
             data.addProperty("test_key_2", "test_value_2");
-            JsonObject metadata = new JsonObject();
-            metadata.addProperty("requestId", "12345");
+            HashMap<String, String> metadata = new HashMap<>();
+            metadata.put("requestId", "12345");
             InvokeConnectionResponse connectionResponse = new InvokeConnectionResponse(data, metadata);
             String responseString = "{\"data\":{\"test_key_1\":\"test_value_1\",\"test_key_2\":\"test_value_2\"}," +
                     "\"metadata\":{\"requestId\":\"12345\"}}";
-            Assert.assertEquals(2, connectionResponse.getData().size());
+            Assert.assertNotNull(connectionResponse.getData());
             Assert.assertEquals(responseString, connectionResponse.toString());
             Assert.assertEquals(1, connectionResponse.getMetadata().size());
         } catch (Exception e) {

--- a/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
+++ b/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
@@ -7,6 +7,7 @@ import com.skyflow.enums.Env;
 import com.skyflow.enums.LogLevel;
 import com.skyflow.errors.ErrorCode;
 import com.skyflow.errors.ErrorMessage;
+import com.skyflow.errors.HttpStatus;
 import com.skyflow.errors.SkyflowException;
 import com.skyflow.generated.rest.ApiClient;
 import com.skyflow.generated.rest.api.TokensApi;
@@ -155,8 +156,8 @@ public class VaultControllerTests {
             );
             Assert.assertNull(e.getRequestId());
             Assert.assertNull(e.getGrpcCode());
-            Assert.assertNull(e.getHttpStatus());
-            Assert.assertNull(e.getDetails());
+            Assert.assertTrue(e.getDetails().isEmpty());
+            Assert.assertEquals(HttpStatus.BAD_REQUEST.getHttpStatus(), e.getHttpStatus());
         }
     }
 


### PR DESCRIPTION
This PR adds an enum for default Http status in validation errors thrown by Java SDK. It also fixes issues in invoke connection flow for outbound connections.
## Why
- Added default Http status for SDK side validation errors.
- Fixed outbound connection flow for invoke connection.
- Fixed error handling in invoke connection.

## Goal
- Will add default Http status for SDK side validation errors.
- Will remove issues with invoke connection flow.
- Will help in reducing inconsistencies and failures in E2E tests.

## Testing
- Fixed failing test cases due to this changes introduced.
- Covered the newly added enum in unit tests.
