### PR TITLE
SK-1890 Add request Ids in response for continue on error failures

### DIFF
--- a/src/main/java/com/skyflow/utils/Constants.java
+++ b/src/main/java/com/skyflow/utils/Constants.java
@@ -24,4 +24,5 @@ public final class Constants {
     public static final String SDK_METRIC_RUNTIME_DETAILS_PREFIX = "Java@";
     public static final String SDK_AUTH_HEADER_KEY = "x-skyflow-authorization";
     public static final String SDK_METRICS_HEADER_KEY = "sky-metadata";
+    public static final String REQUEST_ID_HEADER_KEY = "x-request-id";
 }

--- a/src/main/java/com/skyflow/vault/tokens/DetokenizeRecordResponse.java
+++ b/src/main/java/com/skyflow/vault/tokens/DetokenizeRecordResponse.java
@@ -7,12 +7,18 @@ public class DetokenizeRecordResponse {
     private final String value;
     private final String type;
     private final String error;
+    private final String requestId;
 
     public DetokenizeRecordResponse(V1DetokenizeRecordResponse record) {
+        this(record, null);
+    }
+
+    public DetokenizeRecordResponse(V1DetokenizeRecordResponse record, String requestId) {
         this.token = record.getToken();
         this.value = record.getValue().isEmpty() ? null : record.getValue();
         this.type = record.getValueType().getValue().equals("NONE") ? null : record.getValueType().getValue();
         this.error = record.getError();
+        this.requestId = requestId;
     }
 
     public String getError() {
@@ -29,5 +35,9 @@ public class DetokenizeRecordResponse {
 
     public String getType() {
         return type;
+    }
+
+    public String getRequestId() {
+        return requestId;
     }
 }

--- a/src/test/java/com/skyflow/vault/data/InsertTests.java
+++ b/src/test/java/com/skyflow/vault/data/InsertTests.java
@@ -22,6 +22,7 @@ import java.util.HashMap;
 public class InsertTests {
     private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
     private static final String EXCEPTION_NOT_THROWN = "Should have thrown an exception";
+    private static final String requestId = "95be08fc-4d13-4335-8b8d-24e85d53ed1d";
     private static String vaultID = null;
     private static String clusterID = null;
     private static String table = null;
@@ -408,6 +409,11 @@ public class InsertTests {
     public void testInsertResponse() {
         try {
             ArrayList<HashMap<String, Object>> errorFields = new ArrayList<>();
+            HashMap<String, Object> error = new HashMap<>();
+            error.put("requestIndex", 0);
+            error.put("requestId", requestId);
+            error.put("error", "Insert failed");
+            errorFields.add(error);
             values.add(valueMap);
             values.add(valueMap);
             InsertResponse response = new InsertResponse(values, errorFields);
@@ -416,9 +422,9 @@ public class InsertTests {
                     "\"test_column_2\":\"test_value_2\"}," +
                     "{\"test_column_1\":\"test_value_1\"," +
                     "\"test_column_2\":\"test_value_2\"}]" +
-                    ",\"errors\":" + errorFields + "}";
+                    ",\"errors\":[{\"requestIndex\":0,\"requestId\":\"" + requestId + "\",\"error\":\"Insert failed\"}]}";
             Assert.assertEquals(2, response.getInsertedFields().size());
-            Assert.assertTrue(response.getErrors().isEmpty());
+            Assert.assertEquals(1, response.getErrors().size());
             Assert.assertEquals(responseString, response.toString());
         } catch (Exception e) {
             Assert.fail(INVALID_EXCEPTION_THROWN);

--- a/src/test/java/com/skyflow/vault/tokens/DetokenizeTests.java
+++ b/src/test/java/com/skyflow/vault/tokens/DetokenizeTests.java
@@ -19,6 +19,7 @@ import java.util.ArrayList;
 public class DetokenizeTests {
     private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
     private static final String EXCEPTION_NOT_THROWN = "Should have thrown an exception";
+    private static final String requestId = "95be08fc-4d13-4335-8b8d-24e85d53ed1d";
     private static ArrayList<DetokenizeData> detokenizeData = null;
     private static DetokenizeData maskedRedactionRecord = null;
     private static DetokenizeData plainRedactionRecord = null;
@@ -156,7 +157,7 @@ public class DetokenizeTests {
             record2.setToken("3456-7890-1234-5678");
             record2.setValue("");
             record2.setError("Invalid token");
-            DetokenizeRecordResponse error = new DetokenizeRecordResponse(record2);
+            DetokenizeRecordResponse error = new DetokenizeRecordResponse(record2, requestId);
 
             ArrayList<DetokenizeRecordResponse> fields = new ArrayList<>();
             fields.add(field);
@@ -170,14 +171,15 @@ public class DetokenizeTests {
             String responseString = "{\"detokenizedFields\":[{" +
                     "\"token\":\"1234-5678-9012-3456\",\"value\":\"4111111111111111\",\"type\":\"STRING\"}," +
                     "{\"token\":\"1234-5678-9012-3456\",\"value\":\"4111111111111111\",\"type\":\"STRING\"}]," +
-                    "\"errors\":[{\"token\":\"3456-7890-1234-5678\",\"error\":\"Invalid token\"}," +
-                    "{\"token\":\"3456-7890-1234-5678\",\"error\":\"Invalid token\"}]}";
+                    "\"errors\":[{\"token\":\"3456-7890-1234-5678\",\"error\":\"Invalid token\",\"requestId\":\"" + requestId + "\"}," +
+                    "{\"token\":\"3456-7890-1234-5678\",\"error\":\"Invalid token\",\"requestId\":\"" + requestId + "\"}]}";
             Assert.assertEquals(2, response.getDetokenizedFields().size());
             Assert.assertEquals(2, response.getErrors().size());
             Assert.assertEquals("1234-5678-9012-3456", response.getDetokenizedFields().get(0).getToken());
             Assert.assertEquals("4111111111111111", response.getDetokenizedFields().get(0).getValue());
             Assert.assertEquals("STRING", response.getDetokenizedFields().get(0).getType());
             Assert.assertEquals("Invalid token", response.getErrors().get(0).getError());
+            Assert.assertEquals(requestId, response.getErrors().get(0).getRequestId());
             Assert.assertEquals(responseString, response.toString());
         } catch (Exception e) {
             Assert.fail(INVALID_EXCEPTION_THROWN);


### PR DESCRIPTION
This PR addresses feedback for `insert` and `detokenize` methods SDK responses when `continueOnError` flag is `true`.
## Why
- When `continueOnError` flag is set to `true`, `requestId` is not present for failed requests.
- The absence of `requestId` makes it difficult to debug and troubleshoot these failed requests effectively.

## Goal
- `requestId` will be present for `detokenize` failure responses when `continueOnError` is `true`
- `requestId` will be present for `insert` failure responses when `continueOnError` is `true`

## Testing
- The changes were tested manually.
- Modified unit tests to check for presence of `requestId` in failed request responses when `continueOnError` is `true`