### PR TITLE
SK-2071: Implement Deidentify File Interface and Polling for Detect Support

### DIFF
--- a/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -129,6 +129,21 @@ public enum ErrorMessage {
     InvalidEmptyTextInDeIdentify("%s0 Validation error. The text field is required string and must not be empty string. Specify a valid text."),
     InvalidNullTextInReIdentify("%s0 Validation error. The text field is required string and must not be null. Specify a valid text."),
     InvalidEmptyTextInReIdentify("%s0 Validation error. The text field is required string and must not be empty string. Specify a valid text."),
+
+    //Detect Files
+    InvalidNullFileInDeIdentifyFile("%s0 Validation error. The file field is required and must not be null. Specify a valid file object."),
+    FileNotFoundToDeidentify("%s0 Validation error. The file to deidentify was not found at the specified path. Verify the file path and try again."),
+    FileNotReadableToDeidentify("%s0 Validation error. The file to deidentify is not readable. Check the file permissions and try again."),
+    InvalidPixelDensityToDeidentifyFile("%s0 Validation error. Should be a positive integer. Specify a valid pixel density."),
+    InvalidMaxResolution("%s0 Validation error. Should be a positive integer. Specify a valid max resolution."),
+    OutputDirectoryNotFound("%s0 Validation error. The output directory for deidentified files was not found at the specified path. Verify the output directory path and try again."),
+    InvalidPermission("%s0 Validation error. The output directory for deidentified files is not writable. Check the directory permissions and try again."),
+    InvalidWaitTime("%s0 Validation error. The wait time for deidentify file operation should be a positive integer. Specify a valid wait time."),
+    WaitTimeExceedsLimit("%s0 Validation error. The wait time for deidentify file operation exceeds the maximum limit of 64 seconds. Specify a wait time less than or equal to 60 seconds."),
+    InvalidOrEmptyRunId("%s0 Validation error. The run ID is invalid or empty. Specify a valid run ID."),
+    FailedToEncodeFile("%s0 Validation error. Failed to encode the file. Ensure the file is in a supported format and try again."),
+    PollingForResultsFailed("%s0 API error. Polling for results failed. Unable to retrieve the deidentified file"),
+    FailedtoSaveProcessedFile("%s0 Validation error. Failed to save the processed file. Ensure the output directory is valid and writable."),
     ;
     private final String message;
 

--- a/src/main/java/com/skyflow/errors/SkyflowException.java
+++ b/src/main/java/com/skyflow/errors/SkyflowException.java
@@ -61,7 +61,6 @@ public class SkyflowException extends Exception {
         }
     }
 
-    // Handles new error structure: {error={grpc_code=3, http_code=400, message=..., http_status=..., details=[]}}
     private void setResponseBodyFromJson(String responseBody, Map<String, List<String>> responseHeaders) {
         try {
             if (responseBody != null) {

--- a/src/main/java/com/skyflow/generated/rest/core/ClientOptions.java
+++ b/src/main/java/com/skyflow/generated/rest/core/ClientOptions.java
@@ -34,7 +34,7 @@ public final class ClientOptions {
             {
                 put("X-Fern-Language", "JAVA");
                 put("X-Fern-SDK-Name", "com.skyflow.fern:api-sdk");
-                put("X-Fern-SDK-Version", "0.0.202");
+                put("X-Fern-SDK-Version", "0.0.208");
             }
         });
         this.headerSuppliers = headerSuppliers;

--- a/src/main/java/com/skyflow/generated/rest/resources/files/types/DeidentifyImageRequestMaskingMethod.java
+++ b/src/main/java/com/skyflow/generated/rest/resources/files/types/DeidentifyImageRequestMaskingMethod.java
@@ -6,7 +6,7 @@ package com.skyflow.generated.rest.resources.files.types;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum DeidentifyImageRequestMaskingMethod {
-    BLACKOUT("blackout"),
+    BLACKBOX("blackbox"),
 
     BLUR("blur");
 

--- a/src/main/java/com/skyflow/generated/rest/types/DeidentifyStatusResponseOutputType.java
+++ b/src/main/java/com/skyflow/generated/rest/types/DeidentifyStatusResponseOutputType.java
@@ -6,9 +6,11 @@ package com.skyflow.generated.rest.types;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum DeidentifyStatusResponseOutputType {
-    BASE_64("base64"),
+    BASE_64("BASE64"),
 
-    EFS_PATH("efs_path");
+    EFS_PATH("EFS_PATH"),
+
+    UNKNOWN("UNKNOWN");
 
     private final String value;
 

--- a/src/main/java/com/skyflow/generated/rest/types/DeidentifyStatusResponseStatus.java
+++ b/src/main/java/com/skyflow/generated/rest/types/DeidentifyStatusResponseStatus.java
@@ -6,11 +6,11 @@ package com.skyflow.generated.rest.types;
 import com.fasterxml.jackson.annotation.JsonValue;
 
 public enum DeidentifyStatusResponseStatus {
-    FAILED("failed"),
+    FAILED("FAILED"),
 
-    IN_PROGRESS("in_progress"),
+    IN_PROGRESS("IN_PROGRESS"),
 
-    SUCCESS("success");
+    SUCCESS("SUCCESS");
 
     private final String value;
 

--- a/src/main/java/com/skyflow/generated/rest/types/ReidentifyStringResponse.java
+++ b/src/main/java/com/skyflow/generated/rest/types/ReidentifyStringResponse.java
@@ -20,21 +20,21 @@ import java.util.Optional;
 @JsonInclude(JsonInclude.Include.NON_ABSENT)
 @JsonDeserialize(builder = ReidentifyStringResponse.Builder.class)
 public final class ReidentifyStringResponse {
-    private final Optional<String> processedText;
+    private final Optional<String> text;
 
     private final Map<String, Object> additionalProperties;
 
-    private ReidentifyStringResponse(Optional<String> processedText, Map<String, Object> additionalProperties) {
-        this.processedText = processedText;
+    private ReidentifyStringResponse(Optional<String> text, Map<String, Object> additionalProperties) {
+        this.text = text;
         this.additionalProperties = additionalProperties;
     }
 
     /**
      * @return Re-identified text.
      */
-    @JsonProperty("processed_text")
-    public Optional<String> getProcessedText() {
-        return processedText;
+    @JsonProperty("text")
+    public Optional<String> getText() {
+        return text;
     }
 
     @java.lang.Override
@@ -49,12 +49,12 @@ public final class ReidentifyStringResponse {
     }
 
     private boolean equalTo(ReidentifyStringResponse other) {
-        return processedText.equals(other.processedText);
+        return text.equals(other.text);
     }
 
     @java.lang.Override
     public int hashCode() {
-        return Objects.hash(this.processedText);
+        return Objects.hash(this.text);
     }
 
     @java.lang.Override
@@ -68,7 +68,7 @@ public final class ReidentifyStringResponse {
 
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static final class Builder {
-        private Optional<String> processedText = Optional.empty();
+        private Optional<String> text = Optional.empty();
 
         @JsonAnySetter
         private Map<String, Object> additionalProperties = new HashMap<>();
@@ -76,23 +76,23 @@ public final class ReidentifyStringResponse {
         private Builder() {}
 
         public Builder from(ReidentifyStringResponse other) {
-            processedText(other.getProcessedText());
+            text(other.getText());
             return this;
         }
 
-        @JsonSetter(value = "processed_text", nulls = Nulls.SKIP)
-        public Builder processedText(Optional<String> processedText) {
-            this.processedText = processedText;
+        @JsonSetter(value = "text", nulls = Nulls.SKIP)
+        public Builder text(Optional<String> text) {
+            this.text = text;
             return this;
         }
 
-        public Builder processedText(String processedText) {
-            this.processedText = Optional.ofNullable(processedText);
+        public Builder text(String text) {
+            this.text = Optional.ofNullable(text);
             return this;
         }
 
         public ReidentifyStringResponse build() {
-            return new ReidentifyStringResponse(processedText, additionalProperties);
+            return new ReidentifyStringResponse(text, additionalProperties);
         }
     }
 }

--- a/src/main/java/com/skyflow/logs/ErrorLogs.java
+++ b/src/main/java/com/skyflow/logs/ErrorLogs.java
@@ -117,7 +117,16 @@ public enum ErrorLogs {
     INVALID_NULL_TEXT_IN_REIDENTIFY("Invalid %s1 request. The text field is required string and must not be null. Specify a valid text."),
     INVALID_EMPTY_TEXT_IN_REIDENTIFY("Invalid %s1 request. The text field is required string and must not be empty string. Specify a valid text."),
     REIDENTIFY_TEXT_REQUEST_REJECTED("ReIdentify text request resulted in failure."),
-
+    DEIDENTIFY_FILE_REQUEST_REJECTED("DeIdentify file request resulted in failure."),
+    GET_DETECT_RUN_REQUEST_REJECTED("Get detect run request resulted in failure."),
+    INVALID_NULL_FILE_IN_DEIDENTIFY_FILE("Invalid %s1 request. The file field is required and must not be null. Specify a valid file."),
+    FILE_NOT_FOUND_TO_DEIDENTIFY("Invalid %s1 request. The file field is required and must not be empty. Specify a valid file."),
+    FILE_NOT_READABLE_TO_DEIDENTIFY("Invalid %s1 request. The file is not readable. Please check the file permissions or path."),
+    INVALID_PIXEL_DENSITY_TO_DEIDENTIFY_FILE("Invalid %s1 request. Pixel density must be a positive integer greater than 0. Specify a valid pixel density."),
+    INVALID_MAX_RESOLUTION("Invalid %s1 request. Max resolution must be a positive integer greater than 0. Specify a valid max resolution."),
+    INVALID_BLEEP_TO_DEIDENTIFY_AUDIO("Invalid %s1 request. Specify a valid bleep as AudioBleep"),
+    OUTPUT_DIRECTORY_NOT_FOUND("Invalid %s1 request. The output directory does not exist. Please specify a valid output directory."),
+    INVALID_PERMISSIONS_FOR_OUTPUT_DIRECTORY("Invalid %s1 request. The output directory is not writable. Please check the permissions or specify a valid output directory."),
     ;
 
     private final String log;

--- a/src/main/java/com/skyflow/logs/InfoLogs.java
+++ b/src/main/java/com/skyflow/logs/InfoLogs.java
@@ -83,6 +83,12 @@ public enum InfoLogs {
     VALIDATE_REIDENTIFY_TEXT_REQUEST("Validating reidentify text request."),
     REIDENTIFY_TEXT_TRIGGERED("ReIdentify text method triggered."),
     REIDENTIFY_TEXT_REQUEST_RESOLVED("ReIdentify text request resolved."),
+    DEIDENTIFY_FILE_TRIGGERED("DeIdentify file method triggered."),
+    VALIDATE_DEIDENTIFY_FILE_REQUEST("Validating deidentify file request."),
+    DEIDENTIFY_FILE_REQUEST_RESOLVED("DeIdentify file request resolved."),
+    DEIDENTIFY_FILE_SUCCESS("File deidentified successfully."),
+    GET_DETECT_RUN_TRIGGERED("Get detect run method triggered."),
+    VALIDATE_GET_DETECT_RUN_REQUEST("Validating get detect run request."),
     REIDENTIFY_TEXT_SUCCESS("Text data re-identified."),
     ;
 

--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -17,13 +17,13 @@ import com.skyflow.utils.Utils;
 import com.skyflow.utils.logger.LogUtil;
 import com.skyflow.vault.connection.InvokeConnectionRequest;
 import com.skyflow.vault.data.*;
-import com.skyflow.vault.detect.DeidentifyTextRequest;
-import com.skyflow.vault.detect.ReidentifyTextRequest;
+import com.skyflow.vault.detect.*;
 import com.skyflow.vault.tokens.ColumnValue;
 import com.skyflow.vault.tokens.DetokenizeData;
 import com.skyflow.vault.tokens.DetokenizeRequest;
 import com.skyflow.vault.tokens.TokenizeRequest;
 
+import java.io.File;
 import java.net.URL;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -185,12 +185,12 @@ public class Validations {
                 LogUtil.printErrorLog(ErrorLogs.EMPTY_API_KEY_VALUE.getLog());
                 throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyApikey.getMessage());
             } else {
-                Pattern pattern = Pattern.compile(Constants.API_KEY_REGEX);
-                Matcher matcher = pattern.matcher(apiKey);
-                if (!matcher.matches()) {
-                    LogUtil.printErrorLog(ErrorLogs.INVALID_API_KEY.getLog());
-                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidApikey.getMessage());
-                }
+//                Pattern pattern = Pattern.compile(Constants.API_KEY_REGEX);
+//                Matcher matcher = pattern.matcher(apiKey);
+//                if (!matcher.matches()) {
+//                    LogUtil.printErrorLog(ErrorLogs.INVALID_API_KEY.getLog());
+//                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidApikey.getMessage());
+//                }
             }
         } else if (roles != null) {
             if (roles.isEmpty()) {
@@ -790,6 +790,105 @@ public class Validations {
                     throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyValueInTokens.getMessage());
                 }
             }
+        }
+    }
+
+    public static void validateDeidentifyFileRequest(DeidentifyFileRequest request) throws SkyflowException {
+        if (request == null) {
+            LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.EMPTY_REQUEST_BODY.getLog(), InterfaceName.DETECT.getName()
+            ));
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyRequestBody.getMessage());
+        }
+
+        File file = request.getFile();
+        if (file == null) {
+            LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.INVALID_NULL_FILE_IN_DEIDENTIFY_FILE.getLog(), InterfaceName.DETECT.getName()
+            ));
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidNullFileInDeIdentifyFile.getMessage());
+        }
+        if (!file.exists() || !file.isFile()) {
+            LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.FILE_NOT_FOUND_TO_DEIDENTIFY.getLog(), InterfaceName.DETECT.getName()
+            ));
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.FileNotFoundToDeidentify.getMessage());
+        }
+        if (!file.canRead()) {
+            LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.FILE_NOT_READABLE_TO_DEIDENTIFY.getLog(), InterfaceName.DETECT.getName()
+            ));
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.FileNotReadableToDeidentify.getMessage());
+        }
+
+
+        // Validate pixelDensity and maxResolution
+        if (request.getPixelDensity() != null && request.getPixelDensity().doubleValue() <= 0) {
+            LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.INVALID_PIXEL_DENSITY_TO_DEIDENTIFY_FILE.getLog(), InterfaceName.DETECT.getName()
+            ));
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidPixelDensityToDeidentifyFile.getMessage());
+        }
+        if (request.getMaxResolution() != null && request.getMaxResolution().doubleValue() <= 0) {
+            LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.INVALID_MAX_RESOLUTION.getLog(), InterfaceName.DETECT.getName()
+            ));
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidMaxResolution.getMessage());
+        }
+
+        // Validate AudioBleep
+        if (request.getBleep() != null) {
+            if (request.getBleep().getFrequency() == null || request.getBleep().getFrequency() <= 0) {
+                LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.INVALID_BLEEP_TO_DEIDENTIFY_AUDIO.getLog(), InterfaceName.DETECT.getName()
+                ));
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidRequestBody.getMessage());
+            }
+            if (request.getBleep().getGain() == null || request.getBleep().getGain() < 0) {
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidRequestBody.getMessage());
+            }
+            if (request.getBleep().getStartPadding() == null || request.getBleep().getStartPadding() < 0) {
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidRequestBody.getMessage());
+            }
+            if (request.getBleep().getStopPadding() == null || request.getBleep().getStopPadding() < 0) {
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidRequestBody.getMessage());
+            }
+        }
+
+        // Validate outputDirectory if provided
+        if (request.getOutputDirectory() != null) {
+            File outDir = new File(request.getOutputDirectory());
+            if (!outDir.exists() || !outDir.isDirectory()) {
+                LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.OUTPUT_DIRECTORY_NOT_FOUND.getLog(), InterfaceName.DETECT.getName()
+                ));
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.OutputDirectoryNotFound.getMessage());
+            }
+            if (!outDir.canWrite()) {
+                LogUtil.printErrorLog(Utils.parameterizedString(
+                    ErrorLogs.INVALID_PERMISSIONS_FOR_OUTPUT_DIRECTORY.getLog(), InterfaceName.DETECT.getName()
+                ));
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidPermission.getMessage());
+            }
+        }
+
+        // Validate waitTime if provided
+        if (request.getWaitTime() != null && request.getWaitTime() <= 0) {
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidWaitTime.getMessage());
+        }
+        if(request.getWaitTime() > 64) {
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.WaitTimeExceedsLimit.getMessage());
+        }
+    }
+
+    public static void validateGetDetectRunRequest(GetDetectRunRequest request) throws SkyflowException {
+        if (request == null) {
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyRequestBody.getMessage());
+        }
+
+        String runId = request.getRunId();
+        if (runId == null || runId.trim().isEmpty()) {
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidOrEmptyRunId.getMessage());
         }
     }
 }

--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -185,12 +185,12 @@ public class Validations {
                 LogUtil.printErrorLog(ErrorLogs.EMPTY_API_KEY_VALUE.getLog());
                 throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyApikey.getMessage());
             } else {
-//                Pattern pattern = Pattern.compile(Constants.API_KEY_REGEX);
-//                Matcher matcher = pattern.matcher(apiKey);
-//                if (!matcher.matches()) {
-//                    LogUtil.printErrorLog(ErrorLogs.INVALID_API_KEY.getLog());
-//                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidApikey.getMessage());
-//                }
+               Pattern pattern = Pattern.compile(Constants.API_KEY_REGEX);
+               Matcher matcher = pattern.matcher(apiKey);
+               if (!matcher.matches()) {
+                   LogUtil.printErrorLog(ErrorLogs.INVALID_API_KEY.getLog());
+                   throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidApikey.getMessage());
+               }
             }
         } else if (roles != null) {
             if (roles.isEmpty()) {

--- a/src/main/java/com/skyflow/vault/controller/DetectController.java
+++ b/src/main/java/com/skyflow/vault/controller/DetectController.java
@@ -3,21 +3,27 @@ package com.skyflow.vault.controller;
 import com.skyflow.VaultClient;
 import com.skyflow.config.Credentials;
 import com.skyflow.config.VaultConfig;
+import com.skyflow.errors.ErrorCode;
+import com.skyflow.errors.ErrorMessage;
 import com.skyflow.errors.SkyflowException;
 import com.skyflow.generated.rest.core.ApiClientApiException;
+import com.skyflow.generated.rest.resources.files.requests.*;
 import com.skyflow.generated.rest.resources.strings.requests.DeidentifyStringRequest;
 import com.skyflow.generated.rest.resources.strings.requests.ReidentifyStringRequest;
-import com.skyflow.generated.rest.types.DeidentifyStringResponse;
-import com.skyflow.generated.rest.types.ReidentifyStringResponse;
+import com.skyflow.generated.rest.types.*;
 import com.skyflow.logs.ErrorLogs;
 import com.skyflow.logs.InfoLogs;
 import com.skyflow.utils.logger.LogUtil;
 import com.skyflow.utils.validations.Validations;
+import com.skyflow.vault.detect.*;
+import com.skyflow.vault.detect.DeidentifyFileRequest;
+import com.skyflow.vault.detect.DeidentifyFileResponse;
 import com.skyflow.vault.detect.DeidentifyTextRequest;
-import com.skyflow.vault.detect.DeidentifyTextResponse;
-import com.skyflow.vault.detect.ReidentifyTextRequest;
-import com.skyflow.vault.detect.ReidentifyTextResponse;
 
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.*;
 
 public final class DetectController extends VaultClient {
 
@@ -72,7 +78,7 @@ public final class DetectController extends VaultClient {
             ReidentifyStringResponse reidentifyStringResponse = super.getDetectTextApi().reidentifyString(request);
 
             // Parse the response to ReidentifyTextResponse
-            reidentifyTextResponse = new ReidentifyTextResponse(reidentifyStringResponse.getAdditionalProperties().get("text").toString());
+            reidentifyTextResponse = new ReidentifyTextResponse(reidentifyStringResponse.getText().orElse(null));
             LogUtil.printInfoLog(InfoLogs.REIDENTIFY_TEXT_REQUEST_RESOLVED.getLog());
         } catch (ApiClientApiException ex) {
             LogUtil.printErrorLog(ErrorLogs.REIDENTIFY_TEXT_REQUEST_REJECTED.getLog());
@@ -83,5 +89,278 @@ public final class DetectController extends VaultClient {
         }
         LogUtil.printInfoLog(InfoLogs.REIDENTIFY_TEXT_SUCCESS.getLog());
         return reidentifyTextResponse;
+    }
+
+    public DeidentifyFileResponse deidentifyFile(DeidentifyFileRequest request) throws SkyflowException {
+        DeidentifyFileResponse response;
+        LogUtil.printInfoLog(InfoLogs.DEIDENTIFY_FILE_TRIGGERED.getLog());
+        try {
+            LogUtil.printInfoLog(InfoLogs.VALIDATE_DEIDENTIFY_FILE_REQUEST.getLog());
+            Validations.validateDeidentifyFileRequest(request);
+            setBearerToken();
+
+            String vaultId = super.getVaultConfig().getVaultId();
+
+            File file = request.getFile();
+            String fileName = file.getName();
+            String fileExtension = getFileExtension(fileName);
+            String base64Content;
+
+            try {
+                base64Content = encodeFileToBase64(file);
+            } catch (IOException ioe) {
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.FailedToEncodeFile.getMessage());
+            }
+
+
+            com.skyflow.generated.rest.types.DeidentifyFileResponse apiResponse = processFileByType(fileExtension, base64Content, request, vaultId);
+            try {
+                response = pollForResults(apiResponse.getRunId(), request.getWaitTime());
+            } catch (Exception ex) {
+                throw new SkyflowException(ErrorCode.SERVER_ERROR.getCode(), ErrorMessage.PollingForResultsFailed.getMessage());
+}
+
+            if ("SUCCESS".equalsIgnoreCase(response.getStatus())) {
+                String base64File = response.getFile();
+                if (base64File != null) {
+                    byte[] decodedBytes = Base64.getDecoder().decode(base64File);
+                    String outputDir = request.getOutputDirectory();
+                    String outputFileName = "processed-" + fileName;
+                    File outputFile;
+                    if (outputDir != null && !outputDir.isEmpty()) {
+                        outputFile = new File(outputDir, outputFileName);
+                    } else {
+                        outputFile = new File(outputFileName);
+                    }
+                    try {
+                        java.nio.file.Files.write(outputFile.toPath(), decodedBytes);
+                    } catch (IOException ioe) {
+                        throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.FailedtoSaveProcessedFile.getMessage());
+                    }
+
+                }
+            }
+        } catch (ApiClientApiException e) {
+            LogUtil.printErrorLog(ErrorLogs.DEIDENTIFY_FILE_REQUEST_REJECTED.getLog());
+            throw new SkyflowException(e.statusCode(), e, e.headers(), e.body().toString());
+        }
+        return response;
+    }
+
+    private String getFileExtension(String fileName) {
+        return fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
+    }
+
+    private String encodeFileToBase64(File file) throws IOException {
+        byte[] fileContent = Files.readAllBytes(file.toPath());
+        return Base64.getEncoder().encodeToString(fileContent);
+    }
+
+    private DeidentifyFileResponse pollForResults(String runId, Integer maxWaitTime) throws Exception {
+        int currentWaitTime = 1;
+        maxWaitTime = maxWaitTime == null ? 64 : maxWaitTime;
+
+        DeidentifyStatusResponse response = null;
+
+        while (true) {
+            try {
+                GetRunRequest getRunRequest = GetRunRequest.builder()
+                    .vaultId(super.getVaultConfig().getVaultId())
+                    .build();
+                response = super.getDetectFileAPi()
+                        .getRun(runId, getRunRequest);
+
+                DeidentifyStatusResponseStatus status = response.getStatus();
+
+                if (Objects.equals(status.toString(), "IN_PROGRESS")) {
+                    if (currentWaitTime >= maxWaitTime) {
+                        return new DeidentifyFileResponse(
+                                null,  // file
+                                null,  // type
+                                null,  // extension
+                                null,  // wordCount
+                                null,  // charCount
+                                null,  // sizeInKb
+                                null,  // durationInSeconds
+                                null,  // pageCount
+                                null,  // slideCount
+                                null,  // entities
+                                runId, // runId
+                                "IN_PROGRESS", // status
+                                null   // errors
+                        );
+                    }
+
+                    int nextWaitTime = currentWaitTime * 2;
+                    int waitTime;
+
+                    if (nextWaitTime >= maxWaitTime) {
+                        waitTime = maxWaitTime - currentWaitTime;
+                        currentWaitTime = maxWaitTime;
+                    } else {
+                        waitTime = nextWaitTime;
+                        currentWaitTime = nextWaitTime;
+                    }
+
+                    Thread.sleep(waitTime * 1000);
+
+                } else if (status == DeidentifyStatusResponseStatus.SUCCESS ||
+                        status == DeidentifyStatusResponseStatus.FAILED) {
+                    return parseDeidentifyFileResponse(response, runId, status.toString().toLowerCase());
+                }
+            } catch (ApiClientApiException e) {
+                LogUtil.printErrorLog(ErrorLogs.GET_DETECT_RUN_REQUEST_REJECTED.getLog());
+                throw new SkyflowException(e.statusCode(), e, e.headers(), e.body().toString());
+            }
+        }
+
+    }
+
+
+    private static synchronized DeidentifyFileResponse parseDeidentifyFileResponse(DeidentifyStatusResponse response,
+                                                               String runId, String status) {
+        DeidentifyFileOutput firstOutput = getFirstOutput(response);
+
+        Object wordCharObj = response.getAdditionalProperties().get("word_character_count");
+        Integer wordCount = null;
+        Integer charCount = null;
+
+        if (wordCharObj instanceof Map) {
+            Map<?, ?> wordCharMap = (Map<?, ?>) wordCharObj;
+            Object wc = wordCharMap.get("word_count");
+            Object cc = wordCharMap.get("character_count");
+            if (wc instanceof Number) {
+                wordCount = ((Number) wc).intValue();
+            }
+            if (cc instanceof Number) {
+                charCount = ((Number) cc).intValue();
+            }
+        }
+
+
+        return new DeidentifyFileResponse(
+                firstOutput.getProcessedFile().orElse(null),
+                firstOutput.getProcessedFileType().get().toString(),
+                firstOutput.getProcessedFileExtension().get(),
+                wordCount,
+                charCount,
+                response.getSize().map(Double::valueOf).orElse(null),
+                response.getDuration().map(Double::valueOf).orElse(null),
+                response.getPages().orElse(null),
+                response.getSlides().orElse(null),
+                getEntities(response),
+                runId,
+                status,
+                null
+        );
+    }
+
+    private static synchronized DeidentifyFileOutput getFirstOutput(DeidentifyStatusResponse response) {
+        List<DeidentifyFileOutput> outputs = response.getOutput();
+        return outputs != null && !outputs.isEmpty() ? outputs.get(0) : null;
+    }
+
+    private static synchronized List<FileEntityInfo> getEntities(DeidentifyStatusResponse response) {
+        List<FileEntityInfo> entities = new ArrayList<>();
+
+        List<DeidentifyFileOutput> outputs = response.getOutput();
+        DeidentifyFileOutput deidentifyFileOutput = outputs != null && !outputs.isEmpty() ? outputs.get(1) : null;
+
+        if (deidentifyFileOutput != null) {
+                entities.add(new FileEntityInfo(
+                        deidentifyFileOutput.getProcessedFile().orElse(null),
+                        deidentifyFileOutput.getProcessedFileType().orElse(null),
+                        deidentifyFileOutput.getProcessedFileExtension().orElse(null)
+                ));
+        }
+
+        return entities;
+    }
+
+
+    private com.skyflow.generated.rest.types.DeidentifyFileResponse processFileByType(String fileExtension, String base64Content,
+                                                                                      DeidentifyFileRequest request, String vaultId) {
+        switch(fileExtension.toLowerCase()) {
+            case "txt":
+                com.skyflow.generated.rest.resources.files.requests.DeidentifyTextRequest textFileRequest =
+                        super.getDeidentifyTextFileRequest(request, vaultId, base64Content);
+                return super.getDetectFileAPi().deidentifyText(textFileRequest);
+
+            case "mp3":
+            case "wav":
+                DeidentifyAudioRequest audioRequest =
+                        super.getDeidentifyAudioRequest(request, vaultId, base64Content, fileExtension);
+                return super.getDetectFileAPi().deidentifyAudio(audioRequest);
+
+            case "pdf":
+                DeidentifyPdfRequest pdfRequest =
+                        super.getDeidentifyPdfRequest(request, vaultId, base64Content);
+
+                return super.getDetectFileAPi().deidentifyPdf(pdfRequest);
+
+            case "jpg":
+            case "jpeg":
+            case "png":
+            case "bmp":
+            case "tif":
+            case "tiff":
+                DeidentifyImageRequest imageRequest =
+                        super.getDeidentifyImageRequest(request, vaultId, base64Content, fileExtension);
+                return super.getDetectFileAPi().deidentifyImage(imageRequest);
+
+            case "ppt":
+            case "pptx":
+                DeidentifyPresentationRequest presentationRequest =
+                        super.getDeidentifyPresentationRequest(request, vaultId, base64Content, fileExtension);
+                return super.getDetectFileAPi().deidentifyPresentation(presentationRequest);
+
+            case "csv":
+            case "xls":
+            case "xlsx":
+                DeidentifySpreadsheetRequest spreadsheetRequest =
+                        super.getDeidentifySpreadsheetRequest(request, vaultId, base64Content, fileExtension);
+                return super.getDetectFileAPi().deidentifySpreadsheet(spreadsheetRequest);
+
+            case "doc":
+            case "docx":
+                DeidentifyDocumentRequest documentRequest =
+                        super.getDeidentifyDocumentRequest(request, vaultId, base64Content, fileExtension);
+                return super.getDetectFileAPi().deidentifyDocument(documentRequest);
+
+            case "json":
+            case "xml":
+                DeidentifyStructuredTextRequest structuredTextRequest =
+                        super.getDeidentifyStructuredTextRequest(request, vaultId, base64Content, fileExtension);
+                return super.getDetectFileAPi().deidentifyStructuredText(structuredTextRequest);
+
+            default:
+                com.skyflow.generated.rest.resources.files.requests.DeidentifyFileRequest genericFileRequest =
+                        super.getDeidentifyGenericFileRequest(request, vaultId, base64Content, fileExtension);
+                return super.getDetectFileAPi().deidentifyFile(genericFileRequest);
+        }
+    }
+
+    public DeidentifyFileResponse getDetectRun(GetDetectRunRequest request) throws SkyflowException {
+        LogUtil.printInfoLog(InfoLogs.GET_DETECT_RUN_TRIGGERED.getLog());
+        try {
+            LogUtil.printInfoLog(InfoLogs.VALIDATE_GET_DETECT_RUN_REQUEST.getLog());
+            Validations.validateGetDetectRunRequest(request);
+            setBearerToken();
+            String runId = request.getRunId();
+            String vaultId = super.getVaultConfig().getVaultId();
+
+            GetRunRequest getRunRequest =
+                    GetRunRequest.builder()
+                            .vaultId(vaultId)
+                            .build();
+
+            com.skyflow.generated.rest.types.DeidentifyStatusResponse apiResponse =
+                    super.getDetectFileAPi().getRun(runId, getRunRequest);
+
+            return parseDeidentifyFileResponse(apiResponse, runId, apiResponse.getStatus().toString().toLowerCase());
+        } catch (ApiClientApiException e) {
+            LogUtil.printErrorLog(ErrorLogs.GET_DETECT_RUN_REQUEST_REJECTED.getLog());
+            throw new SkyflowException(e.statusCode(), e, e.headers(), e.body().toString());
+        }
     }
 }

--- a/src/main/java/com/skyflow/vault/detect/AudioBleep.java
+++ b/src/main/java/com/skyflow/vault/detect/AudioBleep.java
@@ -1,0 +1,64 @@
+package com.skyflow.vault.detect;
+
+public class AudioBleep {
+    private final AudioBleepBuilder builder;
+
+    private AudioBleep(AudioBleepBuilder builder) {
+        this.builder = builder;
+    }
+
+    public static AudioBleepBuilder builder() {
+        return new AudioBleepBuilder();
+    }
+
+    public Double getGain() {
+        return this.builder.gain;
+    }
+
+    public Double getFrequency() {
+        return this.builder.frequency;
+    }
+
+    public Double getStartPadding() {
+        return this.builder.startPadding;
+    }
+
+    public Double getStopPadding() {
+        return this.builder.stopPadding;
+    }
+
+    public static final class AudioBleepBuilder {
+        private Double gain;
+        private Double frequency;
+        private Double startPadding;
+        private Double stopPadding;
+
+        private AudioBleepBuilder() {
+            // Default constructor
+        }
+
+        public AudioBleepBuilder gain(Double gain) {
+            this.gain = gain;
+            return this;
+        }
+
+        public AudioBleepBuilder frequency(Double frequency) {
+            this.frequency = frequency;
+            return this;
+        }
+
+        public AudioBleepBuilder startPadding(Double startPadding) {
+            this.startPadding = startPadding;
+            return this;
+        }
+
+        public AudioBleepBuilder stopPadding(Double stopPadding) {
+            this.stopPadding = stopPadding;
+            return this;
+        }
+
+        public AudioBleep build() {
+            return new AudioBleep(this);
+        }
+    }
+}

--- a/src/main/java/com/skyflow/vault/detect/DeidentifyFileRequest.java
+++ b/src/main/java/com/skyflow/vault/detect/DeidentifyFileRequest.java
@@ -1,0 +1,193 @@
+package com.skyflow.vault.detect;
+
+import com.skyflow.enums.DetectEntities;
+import com.skyflow.enums.DetectOutputTranscriptions;
+import com.skyflow.enums.MaskingMethod;
+import java.io.File;
+import java.util.List;
+
+public class DeidentifyFileRequest {
+    private final DeidentifyFileRequestBuilder builder;
+
+    private DeidentifyFileRequest(DeidentifyFileRequestBuilder builder) {
+        this.builder = builder;
+    }
+
+    public static DeidentifyFileRequestBuilder builder() {
+        return new DeidentifyFileRequestBuilder();
+    }
+
+    public File getFile() {
+        return this.builder.file;
+    }
+
+    public List<DetectEntities> getEntities() {
+        return this.builder.entities;
+    }
+
+    public List<String> getAllowRegexList() {
+        return this.builder.allowRegexList;
+    }
+
+    public List<String> getRestrictRegexList() {
+        return this.builder.restrictRegexList;
+    }
+
+    public TokenFormat getTokenFormat() {
+        return this.builder.tokenFormat;
+    }
+
+    public Transformations getTransformations() {
+        return this.builder.transformations;
+    }
+
+    public Boolean getOutputProcessedImage() {
+        return this.builder.outputProcessedImage;
+    }
+
+    public Boolean getOutputOcrText() {
+        return this.builder.outputOcrText;
+    }
+
+    public MaskingMethod getMaskingMethod() {
+        return this.builder.maskingMethod;
+    }
+
+    public Number getPixelDensity() {
+        return this.builder.pixelDensity;
+    }
+
+    public Number getMaxResolution() {
+        return this.builder.maxResolution;
+    }
+
+    public Boolean getOutputProcessedAudio() {
+        return this.builder.outputProcessedAudio;
+    }
+
+    public DetectOutputTranscriptions getOutputTranscription() {
+        return this.builder.outputTranscription;
+    }
+
+    public AudioBleep getBleep() {
+        return this.builder.bleep;
+    }
+
+    public String getOutputDirectory() {
+        return this.builder.outputDirectory;
+    }
+
+    public Integer getWaitTime() {
+        return this.builder.waitTime;
+    }
+
+    public static final class DeidentifyFileRequestBuilder {
+        private File file;
+        private List<DetectEntities> entities;
+        private List<String> allowRegexList;
+        private List<String> restrictRegexList;
+        private TokenFormat tokenFormat;
+        private Transformations transformations;
+        private Boolean outputProcessedImage;
+        private Boolean outputOcrText;
+        private MaskingMethod maskingMethod;
+        private Number pixelDensity;
+        private Number maxResolution;
+        private Boolean outputProcessedAudio;
+        private DetectOutputTranscriptions outputTranscription;
+        private AudioBleep bleep;
+        private String outputDirectory;
+        private Integer waitTime;
+
+        private DeidentifyFileRequestBuilder() {
+            // Set default values
+            this.outputProcessedImage = false;
+            this.outputOcrText = false;
+            this.outputProcessedAudio = false;
+        }
+
+        public DeidentifyFileRequestBuilder file(File file) {
+            this.file = file;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder entities(List<DetectEntities> entities) {
+            this.entities = entities;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder allowRegexList(List<String> allowRegexList) {
+            this.allowRegexList = allowRegexList;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder restrictRegexList(List<String> restrictRegexList) {
+            this.restrictRegexList = restrictRegexList;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder tokenFormat(TokenFormat tokenFormat) {
+            this.tokenFormat = tokenFormat;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder transformations(Transformations transformations) {
+            this.transformations = transformations;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder outputProcessedImage(Boolean outputProcessedImage) {
+            this.outputProcessedImage = outputProcessedImage != null ? outputProcessedImage : false;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder outputOcrText(Boolean outputOcrText) {
+            this.outputOcrText = outputOcrText != null ? outputOcrText : false;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder maskingMethod(MaskingMethod maskingMethod) {
+            this.maskingMethod = maskingMethod;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder pixelDensity(Number pixelDensity) {
+            this.pixelDensity = pixelDensity;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder maxResolution(Number maxResolution) {
+            this.maxResolution = maxResolution;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder outputProcessedAudio(Boolean outputProcessedAudio) {
+            this.outputProcessedAudio = outputProcessedAudio != null ? outputProcessedAudio : false;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder outputTranscription(DetectOutputTranscriptions outputTranscription) {
+            this.outputTranscription = outputTranscription;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder bleep(AudioBleep bleep) {
+            this.bleep = bleep;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder outputDirectory(String outputDirectory) {
+            this.outputDirectory = outputDirectory;
+            return this;
+        }
+
+        public DeidentifyFileRequestBuilder waitTime(Integer waitTime) {
+            this.waitTime = waitTime;
+            return this;
+        }
+
+        public DeidentifyFileRequest build() {
+            return new DeidentifyFileRequest(this);
+        }
+    }
+}

--- a/src/main/java/com/skyflow/vault/detect/DeidentifyFileResponse.java
+++ b/src/main/java/com/skyflow/vault/detect/DeidentifyFileResponse.java
@@ -1,0 +1,99 @@
+package com.skyflow.vault.detect;
+
+import com.google.gson.Gson;
+import java.util.List;
+
+public class DeidentifyFileResponse {
+    private final String file;
+    private final String type;
+    private final String extension;
+    private final Integer wordCount;
+    private final Integer charCount;
+    private final Double sizeInKb;
+    private final Double durationInSeconds;
+    private final Integer pageCount;
+    private final Integer slideCount;
+    private final List<FileEntityInfo> entities;
+    private final String runId;
+    private final String status;
+    private final List<String> errors;
+
+
+    public DeidentifyFileResponse(String file, String type, String extension,
+                                  Integer wordCount, Integer charCount, Double sizeInKb,
+                                  Double durationInSeconds, Integer pageCount, Integer slideCount,
+                                  List<FileEntityInfo> entities, String runId, String status, List<String> errors) {
+        this.file = file;
+        this.type = type;
+        this.extension = extension;
+        this.wordCount = wordCount;
+        this.charCount = charCount;
+        this.sizeInKb = sizeInKb;
+        this.durationInSeconds = durationInSeconds;
+        this.pageCount = pageCount;
+        this.slideCount = slideCount;
+        this.entities = entities;
+        this.runId = runId;
+        this.status = status;
+        this.errors = errors;
+    }
+
+
+    public String getFile() {
+        return file;
+    }
+
+    public String getType() {
+        return type;
+    }
+
+    public String getExtension() {
+        return extension;
+    }
+
+    public Integer getWordCount() {
+        return wordCount;
+    }
+
+    public Integer getCharCount() {
+        return charCount;
+    }
+
+    public Double getSizeInKb() {
+        return sizeInKb;
+    }
+
+    public Double getDurationInSeconds() {
+        return durationInSeconds;
+    }
+
+    public Integer getPageCount() {
+        return pageCount;
+    }
+
+    public Integer getSlideCount() {
+        return slideCount;
+    }
+
+    public List<FileEntityInfo> getEntities() {
+        return entities;
+    }
+
+    public String getRunId() {
+        return runId;
+    }
+
+    public String getStatus() {
+        return status;
+    }
+
+    public List<String> getErrors() {
+        return errors;
+    }
+
+    @Override
+    public String toString() {
+        Gson gson = new Gson();
+        return gson.toJson(this);
+    }
+}

--- a/src/main/java/com/skyflow/vault/detect/FileEntityInfo.java
+++ b/src/main/java/com/skyflow/vault/detect/FileEntityInfo.java
@@ -1,0 +1,19 @@
+package com.skyflow.vault.detect;
+
+import com.skyflow.generated.rest.types.DeidentifyFileOutputProcessedFileType;
+
+public class FileEntityInfo {
+    private final String file;
+    private final String type;
+    private final String extension;
+
+    public FileEntityInfo(String file, DeidentifyFileOutputProcessedFileType type, String extension) {
+        this.file = file;
+        this.type = String.valueOf(type);
+        this.extension = extension;
+    }
+
+    public String getFile() { return file; }
+    public String getType() { return type; }
+    public String getExtension() { return extension; }
+}

--- a/src/main/java/com/skyflow/vault/detect/GetDetectRunRequest.java
+++ b/src/main/java/com/skyflow/vault/detect/GetDetectRunRequest.java
@@ -18,6 +18,9 @@ public class GetDetectRunRequest {
     public static final class GetDetectRunRequestBuilder {
         private String runId;
 
+        private GetDetectRunRequestBuilder() {
+        }
+
         public GetDetectRunRequestBuilder runId(String runId) {
             this.runId = runId;
             return this;

--- a/src/main/java/com/skyflow/vault/detect/GetDetectRunRequest.java
+++ b/src/main/java/com/skyflow/vault/detect/GetDetectRunRequest.java
@@ -1,0 +1,30 @@
+package com.skyflow.vault.detect;
+
+public class GetDetectRunRequest {
+    private final String runId;
+
+    private GetDetectRunRequest(GetDetectRunRequestBuilder builder) {
+        this.runId = builder.runId;
+    }
+
+    public static GetDetectRunRequestBuilder builder() {
+        return new GetDetectRunRequestBuilder();
+    }
+
+    public String getRunId() {
+        return this.runId;
+    }
+
+    public static final class GetDetectRunRequestBuilder {
+        private String runId;
+
+        public GetDetectRunRequestBuilder runId(String runId) {
+            this.runId = runId;
+            return this;
+        }
+
+        public GetDetectRunRequest build() {
+            return new GetDetectRunRequest(this);
+        }
+    }
+}

--- a/src/test/java/com/skyflow/errors/SkyflowExceptionTest.java
+++ b/src/test/java/com/skyflow/errors/SkyflowExceptionTest.java
@@ -1,0 +1,84 @@
+package com.skyflow.errors;
+
+import com.google.gson.JsonArray;
+import com.google.gson.JsonObject;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.*;
+
+public class SkyflowExceptionTest {
+
+    @Test
+    public void testConstructorWithMessage() {
+        SkyflowException ex = new SkyflowException("Test message");
+        Assert.assertEquals("Test message", ex.getMessage());
+        Assert.assertNull(ex.getHttpStatus());
+        Assert.assertNull(ex.getGrpcCode());
+    }
+
+    @Test
+    public void testConstructorWithThrowable() {
+        Throwable cause = new RuntimeException("Root cause");
+        SkyflowException ex = new SkyflowException(cause);
+        Assert.assertEquals("Root cause", ex.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithMessageAndCause() {
+        Throwable cause = new RuntimeException("Root cause");
+        SkyflowException ex = new SkyflowException("Test message", cause);
+        Assert.assertEquals("Test message", ex.getMessage());
+    }
+
+    @Test
+    public void testConstructorWithCodeAndMessage() {
+        SkyflowException ex = new SkyflowException(400, "Bad Request");
+        Assert.assertEquals(Integer.valueOf(400), Integer.valueOf(ex.getHttpCode()));
+        Assert.assertEquals("Bad Request", ex.getMessage());
+        Assert.assertEquals("Bad Request", ex.toString().contains("Bad Request") ? "Bad Request" : null);
+    }
+
+    @Test
+    public void testToStringFormat() {
+        SkyflowException ex = new SkyflowException(404, "Not Found");
+        String str = ex.toString();
+        Assert.assertTrue(str.contains("httpCode: 404"));
+        Assert.assertTrue(str.contains("message: Not Found"));
+    }
+
+    @Test
+    public void testConstructorWithJsonErrorBody() {
+        String json = "{\"error\":{\"message\":\"json error\",\"grpc_code\":7,\"http_status\":\"NOT_FOUND\",\"details\":[{\"info\":\"detail1\"}]}}";
+        Map<String, List<String>> headers = new HashMap<>();
+        headers.put("x-request-id", Collections.singletonList("req-123"));
+        SkyflowException ex = new SkyflowException(404, new RuntimeException("fail"), headers, json);
+        Assert.assertEquals("json error", ex.getMessage());
+        Assert.assertEquals(Integer.valueOf(7), ex.getGrpcCode());
+        Assert.assertEquals("NOT_FOUND", ex.getHttpStatus());
+        Assert.assertEquals("req-123", ex.getRequestId());
+        Assert.assertNotNull(ex.getDetails());
+        Assert.assertTrue(ex.getDetails().size() > 0);
+    }
+
+    @Test
+    public void testConstructorWithNonJsonErrorBody() {
+        String errorMsg = "plain error";
+        Map<String, List<String>> headers = new HashMap<>();
+        SkyflowException ex = new SkyflowException(500, new RuntimeException("fail"), headers, errorMsg);
+        Assert.assertEquals(errorMsg, ex.getMessage());
+        Assert.assertNull(ex.getGrpcCode());
+        Assert.assertNull(ex.getHttpStatus());
+    }
+
+    @Test
+    public void testGettersAndSetters() {
+        SkyflowException ex = new SkyflowException("msg");
+        // Simulate setting fields via reflection or constructor
+        // (getters are already tested above)
+        Assert.assertNull(ex.getRequestId());
+        Assert.assertNull(ex.getDetails());
+        Assert.assertNull(ex.getGrpcCode());
+        Assert.assertNull(ex.getHttpStatus());
+    }
+}

--- a/src/test/java/com/skyflow/vault/controller/DetectControllerFileTests.java
+++ b/src/test/java/com/skyflow/vault/controller/DetectControllerFileTests.java
@@ -1,0 +1,237 @@
+package com.skyflow.vault.controller;
+
+import com.skyflow.config.Credentials;
+import com.skyflow.config.VaultConfig;
+import com.skyflow.errors.ErrorCode;
+import com.skyflow.errors.SkyflowException;
+import com.skyflow.vault.detect.AudioBleep;
+import com.skyflow.vault.detect.DeidentifyFileRequest;
+import com.skyflow.vault.detect.GetDetectRunRequest;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.ArrayList;
+
+public class DetectControllerFileTests {
+    private static final String EXCEPTION_NOT_THROWN = "Should have thrown an exception";
+    private static String vaultID = null;
+    private static String clusterID = null;
+    private static VaultConfig vaultConfig = null;
+    private static DetectController detectController = null;
+
+    @BeforeClass
+    public static void setup() {
+        vaultID = "vault123";
+        clusterID = "cluster123";
+
+        Credentials credentials = new Credentials();
+        credentials.setToken("valid-token");
+
+        vaultConfig = new VaultConfig();
+        vaultConfig.setVaultId(vaultID);
+        vaultConfig.setClusterId(clusterID);
+        vaultConfig.setEnv(com.skyflow.enums.Env.DEV);
+        vaultConfig.setCredentials(credentials);
+
+        detectController = new DetectController(vaultConfig, credentials);
+    }
+
+    @Test
+    public void testNullFileInDeidentifyFileRequest() {
+        try {
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder().build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+    }
+
+    @Test
+    public void testUnreadableFileInDeidentifyFileRequest() {
+        try {
+            File file = new File("unreadable.txt") {
+                @Override
+                public boolean exists() { return true; }
+                @Override
+                public boolean isFile() { return true; }
+                @Override
+                public boolean canRead() { return false; }
+            };
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder().file(file).build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException | RuntimeException e) {
+            // Depending on implementation, could be SkyflowException or RuntimeException
+            Assert.assertTrue(e.getMessage().contains("not readable") || e.getMessage().contains("unreadable.txt"));
+        }
+    }
+
+    @Test
+    public void testNullEntitiesInDeidentifyFileRequest() {
+        try {
+            File file = File.createTempFile("test", ".txt");
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .entities(new ArrayList<>())
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+    }
+
+    @Test
+    public void testNullRequest() {
+        try {
+            detectController.deidentifyFile(null);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+    }
+
+    @Test
+    public void testNonExistentFileInDeidentifyFileRequest() {
+        try {
+            File file = new File("nonexistent.txt");
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder().file(file).build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+    }
+
+    @Test
+    public void testInvalidPixelDensity() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .pixelDensity(-1)
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testInvalidMaxResolution() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .maxResolution(-1)
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testInvalidBleepFrequency() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            AudioBleep bleep =  AudioBleep.builder().build();
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .bleep(bleep)
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testInvalidOutputDirectory() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .outputDirectory("not/a/real/dir")
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testInvalidWaitTime() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .waitTime(-1)
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testWaitTimeExceedsLimit() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .waitTime(100)
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testNullGetDetectRunRequest() {
+        try {
+            detectController.getDetectRun(null);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+    }
+
+    @Test
+    public void testEmptyRunIdInGetDetectRunRequest() {
+        try {
+            GetDetectRunRequest request =  GetDetectRunRequest.builder().build();
+            detectController.getDetectRun(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+    }
+
+    @Test
+    public void testNullRunIdInGetDetectRunRequest() {
+        try {
+            GetDetectRunRequest request = GetDetectRunRequest.builder().runId(null).build();
+            detectController.getDetectRun(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+    }
+}

--- a/src/test/java/com/skyflow/vault/controller/DetectControllerFileTests.java
+++ b/src/test/java/com/skyflow/vault/controller/DetectControllerFileTests.java
@@ -12,6 +12,7 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.io.File;
+import java.nio.file.Files;
 import java.util.ArrayList;
 
 public class DetectControllerFileTests {
@@ -232,6 +233,96 @@ public class DetectControllerFileTests {
             Assert.fail(EXCEPTION_NOT_THROWN);
         } catch (Exception e) {
             Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+    }
+
+    @Test
+    public void testInvalidBleepGain() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            AudioBleep bleep = AudioBleep.builder().frequency(440.0).gain(-1.0).startPadding(0.1).stopPadding(0.1).build();
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .bleep(bleep)
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testInvalidBleepStartPadding() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            AudioBleep bleep = AudioBleep.builder().frequency(440.0).gain(0.5).startPadding(-0.1).stopPadding(0.1).build();
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .bleep(bleep)
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testInvalidBleepStopPadding() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        try {
+            AudioBleep bleep = AudioBleep.builder().frequency(440.0).gain(0.5).startPadding(0.1).stopPadding(-0.1).build();
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .bleep(bleep)
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+    }
+
+    @Test
+    public void testOutputDirectoryNotDirectory() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        File notADir = File.createTempFile("notadir", ".txt");
+        try {
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .outputDirectory(notADir.getAbsolutePath())
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        }
+        file.delete();
+        notADir.delete();
+    }
+
+    @Test
+    public void testOutputDirectoryNotWritable() throws Exception {
+        File file = File.createTempFile("test", ".txt");
+        File dir = Files.createTempDirectory("notwritabledir").toFile();
+        dir.setWritable(false);
+        try {
+            DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                    .file(file)
+                    .outputDirectory(dir.getAbsolutePath())
+                    .build();
+            detectController.deidentifyFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (Exception e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), 400);
+        } finally {
+            dir.setWritable(true);
+            file.delete();
+            dir.delete();
         }
     }
 }

--- a/src/test/java/com/skyflow/vault/detect/DeidentifyFileRequestTest.java
+++ b/src/test/java/com/skyflow/vault/detect/DeidentifyFileRequestTest.java
@@ -1,0 +1,59 @@
+package com.skyflow.vault.detect;
+
+import com.skyflow.enums.DetectEntities;
+import com.skyflow.enums.DetectOutputTranscriptions;
+import com.skyflow.enums.MaskingMethod;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.File;
+import java.util.Arrays;
+
+public class DeidentifyFileRequestTest {
+
+    @Test
+    public void testBuilderAndGetters() {
+        File file = new File("test.txt");
+        DetectEntities entity = DetectEntities.DOB;
+        MaskingMethod maskingMethod = MaskingMethod.BLACKBOX;
+        DetectOutputTranscriptions transcription = DetectOutputTranscriptions.TRANSCRIPTION;
+        String outputDir = "/tmp/output";
+        int waitTime = 42;
+
+        DeidentifyFileRequest request = DeidentifyFileRequest.builder()
+                .file(file)
+                .entities(Arrays.asList(entity))
+                .allowRegexList(Arrays.asList("a.*"))
+                .restrictRegexList(Arrays.asList("b.*"))
+                .maskingMethod(maskingMethod)
+                .outputProcessedImage(true)
+                .outputOcrText(true)
+                .outputProcessedAudio(true)
+                .outputTranscription(transcription)
+                .outputDirectory(outputDir)
+                .waitTime(waitTime)
+                .build();
+
+        Assert.assertEquals(file, request.getFile());
+        Assert.assertEquals(entity, request.getEntities().get(0));
+        Assert.assertEquals("a.*", request.getAllowRegexList().get(0));
+        Assert.assertEquals("b.*", request.getRestrictRegexList().get(0));
+        Assert.assertEquals(maskingMethod, request.getMaskingMethod());
+        Assert.assertTrue(request.getOutputProcessedImage());
+        Assert.assertTrue(request.getOutputOcrText());
+        Assert.assertTrue(request.getOutputProcessedAudio());
+        Assert.assertEquals(transcription, request.getOutputTranscription());
+        Assert.assertEquals(outputDir, request.getOutputDirectory());
+        Assert.assertEquals(Integer.valueOf(waitTime), request.getWaitTime());
+    }
+
+    @Test
+    public void testBuilderDefaults() {
+        DeidentifyFileRequest request = DeidentifyFileRequest.builder().build();
+        Assert.assertFalse(request.getOutputProcessedImage());
+        Assert.assertFalse(request.getOutputOcrText());
+        Assert.assertFalse(request.getOutputProcessedAudio());
+        Assert.assertNull(request.getOutputDirectory());
+        Assert.assertNull(request.getWaitTime());
+    }
+}

--- a/src/test/java/com/skyflow/vault/detect/DeidentifyFileResponseTest.java
+++ b/src/test/java/com/skyflow/vault/detect/DeidentifyFileResponseTest.java
@@ -1,0 +1,58 @@
+package com.skyflow.vault.detect;
+
+import com.skyflow.generated.rest.types.DeidentifyFileOutputProcessedFileType;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+public class DeidentifyFileResponseTest {
+
+    @Test
+    public void testAllGettersAndToString() {
+        String file = "output.pdf";
+        String type = "pdf";
+        String extension = ".pdf";
+        Integer wordCount = 100;
+        Integer charCount = 500;
+        Double sizeInKb = 123.45;
+        Double durationInSeconds = 12.3;
+        Integer pageCount = 5;
+        Integer slideCount = 0;
+        FileEntityInfo entityInfo = new FileEntityInfo("PERSON", DeidentifyFileOutputProcessedFileType.ENTITIES, "John Doe");
+        java.util.List<FileEntityInfo> entities = Collections.singletonList(entityInfo);
+        String runId = "run-123";
+        String status = "SUCCESS";
+        java.util.List<String> errors = Arrays.asList("error1", "error2");
+
+        DeidentifyFileResponse response = new DeidentifyFileResponse(
+                file, type, extension, wordCount, charCount, sizeInKb,
+                durationInSeconds, pageCount, slideCount, entities, runId, status, errors
+        );
+
+        Assert.assertEquals(file, response.getFile());
+        Assert.assertEquals(type, response.getType());
+        Assert.assertEquals(extension, response.getExtension());
+        Assert.assertEquals(wordCount, response.getWordCount());
+        Assert.assertEquals(charCount, response.getCharCount());
+        Assert.assertEquals(sizeInKb, response.getSizeInKb());
+        Assert.assertEquals(durationInSeconds, response.getDurationInSeconds());
+        Assert.assertEquals(pageCount, response.getPageCount());
+        Assert.assertEquals(slideCount, response.getSlideCount());
+        Assert.assertEquals(entities, response.getEntities());
+        Assert.assertEquals(runId, response.getRunId());
+        Assert.assertEquals(status, response.getStatus());
+        Assert.assertEquals(errors, response.getErrors());
+
+        // toString should return a JSON string containing all fields
+        String json = response.toString();
+        Assert.assertTrue(json.contains(file));
+        Assert.assertTrue(json.contains(type));
+        Assert.assertTrue(json.contains(extension));
+        Assert.assertTrue(json.contains(runId));
+        Assert.assertTrue(json.contains(status));
+        Assert.assertTrue(json.contains("error1"));
+        Assert.assertTrue(json.contains("PERSON"));
+    }
+}

--- a/src/test/java/com/skyflow/vault/detect/FileEntityInfoTest.java
+++ b/src/test/java/com/skyflow/vault/detect/FileEntityInfoTest.java
@@ -1,0 +1,21 @@
+package com.skyflow.vault.detect;
+
+import com.skyflow.generated.rest.types.DeidentifyFileOutputProcessedFileType;
+import org.junit.Assert;
+import org.junit.Test;
+
+public class FileEntityInfoTest {
+
+    @Test
+    public void testConstructorAndGetters() {
+        String file = "entity.pdf";
+        DeidentifyFileOutputProcessedFileType type = DeidentifyFileOutputProcessedFileType.ENTITIES;
+        String extension = ".pdf";
+
+        FileEntityInfo info = new FileEntityInfo(file, type, extension);
+
+        Assert.assertEquals(file, info.getFile());
+        Assert.assertEquals(type.toString(), info.getType());
+        Assert.assertEquals(extension, info.getExtension());
+    }
+}


### PR DESCRIPTION
**Why**

- Java SDK didn’t support Detect APIs. Developers had to call them manually.

**Outcome**

- Added deidentify file public interface for Detect service in the SDK.