### PR TITLE
SK-2128 Add support for uploading file in Java SDK v2

### DIFF
--- a/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -114,6 +114,21 @@ public enum ErrorMessage {
     ColumnValuesKeyErrorTokenize("%s0 Validation error. 'columnValues' key is missing from the payload. Specify a 'columnValues' key."),
     EmptyColumnGroupInColumnValue("%s0 Validation error. Invalid column group in column value. Specify a valid column group."),
 
+    // Upload file
+    InvalidFileUploadRequest("%s0 Validation error. Invalid file upload request. Specify a valid file upload request."),
+    TableNameKeyError("%s0 Validation error. 'tableName' key is missing from the payload. Specify a 'tableName' key."),
+    EmptyTableName("%s0 Validation error. 'tableName' can't be empty. Specify a table name."),
+    SkyflowIdKeyErrorInFileUpload("%s0 Validation error. 'skyflowId' key is missing from the payload. Specify a 'skyflowId' key."),
+    EmptySkyflowIdInFileUpload("%s0 Validation error. 'skyflowId' can't be empty. Specify a skyflow id."),
+    ColumnNameKeyErrorInFileUpload("%s0 Validation error. 'columnName' can't be empty. Specify a 'columnName' key."),
+    EmptyColumnNameInFileUpload("%s0 Validation error. 'columnName' can't be empty. Specify a column name."),
+    MissingFileSourceInFileUpload("%s0 Validation error. Provide exactly one of filePath, base64, or fileObject."),
+    MultipleFileSourcesInFileUpload("%s0 Validation error. Provide exactly one of filePath, base64, or fileObject."),
+    EmptyFilePathInFileUpload("%s0 Validation error. File path cannot be empty in file upload request. Specify a valid file path."),
+    MissingFileNameForBase64("%s0 Validation error. File name is required when providing a base64 string"),
+    InvalidFileObjectInFileUpload("%s0 Validation error. Invalid file object in file upload request. Specify a valid file object."),
+    InvalidBase64InFileUpload("%s0 Validation error. Invalid base64 string in file upload request. Specify a valid base64 string."),
+
     // Connection
     InvalidRequestHeaders("%s0 Validation error. Request headers aren't valid. Specify valid request headers."),
     EmptyRequestHeaders("%s0 Validation error. Request headers are empty. Specify valid request headers."),
@@ -148,8 +163,7 @@ public enum ErrorMessage {
     FailedtoSaveProcessedFile("%s0 Validation error. Failed to save the processed file. Ensure the output directory is valid and writable."),
     InvalidAudioFileType("%s0 Validation error. The file type is not supported. Specify a valid file type mp3 or wav."),
     // Generic
-    ErrorOccurred("%s0 API error. Error occurred.")
-    ;
+    ErrorOccurred("%s0 API error. Error occurred.");
     private final String message;
 
     ErrorMessage(String message) {

--- a/src/main/java/com/skyflow/logs/ErrorLogs.java
+++ b/src/main/java/com/skyflow/logs/ErrorLogs.java
@@ -96,7 +96,17 @@ public enum ErrorLogs {
     EMPTY_OR_NULL_COLUMN_GROUP_IN_COLUMN_VALUES("Invalid %s1 request. Column group can not be null or empty in column values at index %s2."),
     TOKENIZE_REQUEST_REJECTED("Tokenize request resulted in failure."),
     DELETE_REQUEST_REJECTED("Delete request resulted in failure."),
+    FILE_UPLOAD_REQUEST_REJECTED("File upload request resulted in failure."),
 
+    INVALID_FILE_UPLOAD_REQUEST("Invalid %s1 request. Invalid file upload request. Specify a valid file upload request."),
+    COLUMN_NAME_IS_REQUIRED_IN_FILE_UPLOAD("Invalid %s1 request. Column name is required."),
+    INVALID_FILE_SOURCES_IN_FILE_UPLOAD("Invalid %s1 request. Exactly one of 'filePath', 'base64', or 'fileObject' is required."),
+    MISSING_FILE_PATH_IN_FILE_UPLOAD("Invalid %s1 request. File path cannot be empty in file upload request. Specify a valid file path as string."),
+    MISSING_FILE_NAME_FOR_BASE64("Invalid %s1 request. File name is required when providing a base64 string"),
+    INVALID_FILE_OBJECT_IN_FILE_UPLOAD("Invalid %s1 request. Invalid file object in file upload request. Specify a valid file object."),
+    INVALID_FILE_PATH_IN_FILE_UPLOAD("Invalid %s1 request. Invalid file path in file upload request. Specify a valid file path."),
+    INVALID_BASE64_IN_FILE_UPLOAD("Invalid %s1 request. Invalid base64 string in file upload request. Specify a valid base64 string."),
+    
     // invoke connection interface
     INVOKE_CONNECTION_INVALID_CONNECTION_URL("Invalid %s1 request. Connection URL is not a valid URL."),
     EMPTY_REQUEST_HEADERS("Invalid %s1 request. Request headers can not be empty."),

--- a/src/main/java/com/skyflow/logs/InfoLogs.java
+++ b/src/main/java/com/skyflow/logs/InfoLogs.java
@@ -69,6 +69,11 @@ public enum InfoLogs {
     TOKENIZE_REQUEST_RESOLVED("Tokenize request resolved."),
     TOKENIZE_SUCCESS("Data tokenized."),
 
+    // File upload interface
+    FILE_UPLOAD_TRIGGERED("File upload method triggered."),
+    VALIDATE_FILE_UPLOAD_REQUEST("Validating file upload request."),
+    FILE_UPLOAD_REQUEST_RESOLVED("File upload request resolved."),
+    FILE_UPLOAD_SUCCESS("File uploaded successfully."),
 
     // Invoke connection interface
     INVOKE_CONNECTION_TRIGGERED("Invoke connection method triggered."),

--- a/src/main/java/com/skyflow/vault/data/FileUploadRequest.java
+++ b/src/main/java/com/skyflow/vault/data/FileUploadRequest.java
@@ -1,0 +1,95 @@
+package com.skyflow.vault.data;
+
+import java.io.File;
+
+public class FileUploadRequest {
+  private final FileUploadRequestBuilder builder;
+
+  private FileUploadRequest(FileUploadRequestBuilder builder) {
+    this.builder = builder;
+  }
+
+  public static FileUploadRequestBuilder builder() {
+    return new FileUploadRequestBuilder();
+  }
+
+  public String getTableName() {
+    return this.builder.tableName;
+  }
+
+  public String getColumnName() {
+    return this.builder.columnName;
+  }
+
+  public String getSkyflowId() {
+    return this.builder.skyflowId;
+  }
+
+  public String getFilePath() {
+    return this.builder.filePath;
+  }
+
+  public String getBase64() {
+    return this.builder.base64;
+  }
+
+  public File getFileObject() {
+    return this.builder.fileObject;
+  }
+
+  public String getFileName() {
+    return this.builder.fileName;
+  }
+
+  public static final class FileUploadRequestBuilder {
+    private String tableName;
+    private String columnName;
+    private String skyflowId;
+    private String filePath;
+    private String base64;
+    private File fileObject;
+    private String fileName;
+
+    private FileUploadRequestBuilder() {
+    }
+
+    public FileUploadRequestBuilder tableName(String tableName) {
+      this.tableName = tableName;
+      return this;
+    }
+
+    public FileUploadRequestBuilder columnName(String columnName) {
+      this.columnName = columnName;
+      return this;
+    }
+
+    public FileUploadRequestBuilder skyflowId(String skyflowId) {
+      this.skyflowId = skyflowId;
+      return this;
+    }
+
+    public FileUploadRequestBuilder filePath(String filePath) {
+      this.filePath = filePath;
+      return this;
+    }
+
+    public FileUploadRequestBuilder base64(String base64) {
+      this.base64 = base64;
+      return this;
+    }
+
+    public FileUploadRequestBuilder fileObject(File fileObject) {
+      this.fileObject = fileObject;
+      return this;
+    }
+
+    public FileUploadRequestBuilder fileName(String fileName) {
+      this.fileName = fileName;
+      return this;
+    }
+
+    public FileUploadRequest build() {
+      return new FileUploadRequest(this);
+    }
+  }
+}

--- a/src/main/java/com/skyflow/vault/data/FileUploadResponse.java
+++ b/src/main/java/com/skyflow/vault/data/FileUploadResponse.java
@@ -1,0 +1,23 @@
+package com.skyflow.vault.data;
+
+import com.google.gson.*;
+
+public class FileUploadResponse {
+	private final String skyflowId;
+
+	public FileUploadResponse(String skyflowId) {
+		this.skyflowId = skyflowId;
+	}
+
+	public String getSkyflowId() {
+		return skyflowId;
+	}
+
+	@Override
+	public String toString() {
+		Gson gson = new GsonBuilder().serializeNulls().create();
+		JsonObject responseObject = gson.toJsonTree(this).getAsJsonObject();
+		responseObject.add("errors", null);
+		return responseObject.toString();
+	}
+}

--- a/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
+++ b/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
@@ -165,4 +165,24 @@ public class VaultControllerTests {
         }
     }
 
+    @Test
+    public void testInvalidRequestInUploadFileMethod() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder().build();
+            skyflowClient = Skyflow.builder().setLogLevel(LogLevel.DEBUG).addVaultConfig(vaultConfig).build();
+            skyflowClient.vault().uploadFile(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.TableNameKeyError.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+            Assert.assertNull(e.getRequestId());
+            Assert.assertNull(e.getGrpcCode());
+            Assert.assertTrue(e.getDetails().isEmpty());
+            Assert.assertEquals(HttpStatus.BAD_REQUEST.getHttpStatus(), e.getHttpStatus());
+        }
+    }
+
 }

--- a/src/test/java/com/skyflow/vault/data/FileUploadTests.java
+++ b/src/test/java/com/skyflow/vault/data/FileUploadTests.java
@@ -1,0 +1,359 @@
+package com.skyflow.vault.data;
+
+import com.skyflow.config.Credentials;
+import com.skyflow.config.VaultConfig;
+import com.skyflow.enums.Env;
+import com.skyflow.errors.ErrorCode;
+import com.skyflow.errors.ErrorMessage;
+import com.skyflow.errors.SkyflowException;
+import com.skyflow.utils.Constants;
+import com.skyflow.utils.Utils;
+import com.skyflow.utils.validations.Validations;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.File;
+
+public class FileUploadTests {
+    private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
+    private static final String EXCEPTION_NOT_THROWN = "Should have thrown an exception";
+    private static String vaultID = null;
+    private static String clusterID = null;
+    private static String skyflowID = null;
+    private static String tableName = null;
+    private static String columnName = null;
+    private static String filePath = null;
+    private static String fileName = null;
+    private static File testFile = null;
+    private static String validbase64String = "YmFzZTY0RW5jb2RlZFN0cmluZw==";
+
+    @BeforeClass
+    public static void setup() {
+        vaultID = "vault123";
+        clusterID = "cluster123";
+
+        Credentials credentials = new Credentials();
+        credentials.setToken("valid-token");
+
+        VaultConfig vaultConfig = new VaultConfig();
+        vaultConfig.setVaultId(vaultID);
+        vaultConfig.setClusterId(clusterID);
+        vaultConfig.setEnv(Env.DEV);
+        skyflowID = "test_file_upload_id_1";
+        tableName = "test_table";
+        columnName = "profile_image";
+        fileName = "notJson.txt";
+        filePath = "src/test/resources/" + fileName;
+        testFile = new File(filePath);
+    }
+
+    @Test
+    public void testValidFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(testFile)
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .skyflowId(skyflowID)
+                    .fileName(fileName)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.assertEquals(tableName, request.getTableName());
+            Assert.assertEquals(columnName, request.getColumnName());
+            Assert.assertEquals(testFile, request.getFileObject());
+            Assert.assertEquals(fileName, request.getFileName());
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN + " " + e);
+        }
+    }
+
+    @Test
+    public void testNullRequestInFileUploadRequestValidations() {
+        try {
+            Validations.validateFileUploadRequest(null);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidFileUploadRequest.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testNoTableInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(testFile)
+                    .columnName(columnName)
+                    .fileName(fileName)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.TableNameKeyError.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testEmptyTableInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(testFile)
+                    .tableName("")
+                    .columnName(columnName)
+                    .fileName(fileName)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.EmptyTableName.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testNoColumnInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(testFile)
+                    .tableName(tableName)
+                    .skyflowId(skyflowID)
+                    .fileName(fileName)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.ColumnNameKeyErrorInFileUpload.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testEmptyColumnInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(testFile)
+                    .tableName(tableName)
+                    .columnName("")
+                    .skyflowId(skyflowID)
+                    .fileName(fileName)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.EmptyColumnNameInFileUpload.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testNoSkyflowIdInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(testFile)
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .fileName(fileName)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.SkyflowIdKeyErrorInFileUpload.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testEmptySkyflowIdInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(testFile)
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .fileName(fileName)
+                    .skyflowId("")
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.EmptySkyflowIdInFileUpload.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testNoFileInUploadRequestValidations() {
+        FileUploadRequest request = FileUploadRequest.builder()
+                .tableName(tableName)
+                .columnName(columnName)
+                .skyflowId(skyflowID)
+                .fileName(fileName)
+                .build();
+        try {
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.MissingFileSourceInFileUpload.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testMultipleFileSourcesInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(testFile)
+                    .filePath(filePath)
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .fileName(fileName)
+                    .skyflowId(skyflowID)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.MultipleFileSourcesInFileUpload.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testNoFileNameForBase64InFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .base64(validbase64String)
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .skyflowId(skyflowID)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.MissingFileNameForBase64.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testInvalidFileObjectInFileUploadRequestValidations() {
+        try {
+            File invalidFile = new File("nonexistent.txt");
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .fileObject(invalidFile)
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .fileName(fileName)
+                    .skyflowId(skyflowID)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidFileObjectInFileUpload.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testValidBase64InFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .base64(validbase64String)
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .fileName(fileName)
+                    .skyflowId(skyflowID)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.assertEquals(tableName, request.getTableName());
+            Assert.assertEquals(columnName, request.getColumnName());
+            Assert.assertEquals(fileName, request.getFileName());
+            Assert.assertEquals(validbase64String, request.getBase64());
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testValidFilePathInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .filePath(filePath)
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .skyflowId(skyflowID)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.assertEquals(tableName, request.getTableName());
+            Assert.assertEquals(columnName, request.getColumnName());
+            Assert.assertEquals(filePath, request.getFilePath());
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testEmptyFilePathInFileUploadRequestValidations() {
+        try {
+            FileUploadRequest request = FileUploadRequest.builder()
+                    .filePath("")
+                    .tableName(tableName)
+                    .columnName(columnName)
+                    .skyflowId(skyflowID)
+                    .build();
+            Validations.validateFileUploadRequest(request);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.EmptyFilePathInFileUpload.getMessage(), Constants.SDK_PREFIX),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testFileUploadResponse() {
+        try {
+            FileUploadResponse response = new FileUploadResponse(skyflowID);
+            String responseString = "{\"skyflowId\":\"" + skyflowID + "\",\"errors\":null}";
+            Assert.assertEquals(skyflowID, response.getSkyflowId());
+            Assert.assertEquals(responseString, response.toString());
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds changes for supporting file upload operation in Java SDK v2.
## Why
- Java SDK v2 did not support for uploading files.

## Goal
- User should be able to upload file using Java SDK v2.

## Testing
- Added unit tests and tested manually.

