### PR TITLE
SK-2207 Update release workflows and POM

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -11,8 +11,8 @@ jobs:
       profile: maven-central
       tag: 'beta'
     secrets:
-      server-username: ${{ secrets.OSSRH_USERNAME }}
-      server-password: ${{ secrets.OSSRH_PASSWORD }}
+      server-username: ${{ secrets.CENTRAL_PUBLISHER_PORTAL_USERNAME }}
+      server-password: ${{ secrets.CENTRAL_PUBLISHER_PORTAL_PASSWORD }}
       gpg-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
       gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       skyflow-credentials: ${{ secrets.SKYFLOW_CREDENTIALS }} >> .env

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,8 +11,8 @@ jobs:
       profile: maven-central
       tag: 'public'
     secrets:
-      server-username: ${{ secrets.OSSRH_USERNAME }}
-      server-password: ${{ secrets.OSSRH_PASSWORD }}
+      server-username: ${{ secrets.CENTRAL_PUBLISHER_PORTAL_USERNAME }}
+      server-password: ${{ secrets.CENTRAL_PUBLISHER_PORTAL_PASSWORD }}
       gpg-key: ${{ secrets.MAVEN_GPG_PRIVATE_KEY }}
       gpg-passphrase: ${{ secrets.MAVEN_GPG_PASSPHRASE }}
       skyflow-credentials: ${{ secrets.SKYFLOW_CREDENTIALS }} >> .env

--- a/pom.xml
+++ b/pom.xml
@@ -263,25 +263,25 @@
             <id>maven-central</id>
             <distributionManagement>
                 <repository>
-                    <id>ossrh</id>
-                    <url>https://s01.oss.sonatype.org/service/local/staging/deploy/maven2</url>
+                    <id>central</id>
+                    <url>https://central.sonatype.com/api/v1/publisher/upload</url>
                 </repository>
                 <snapshotRepository>
-                    <id>ossrh</id>
-                    <url>https://s01.oss.sonatype.org/content/repositories/snapshots</url>
+                    <id>central-snapshots</id>
+                    <url>https://central.sonatype.com/api/v1/publisher/upload</url>
                 </snapshotRepository>
             </distributionManagement>
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>org.sonatype.plugins</groupId>
-                        <artifactId>nexus-staging-maven-plugin</artifactId>
-                        <version>1.6.7</version>
+                        <groupId>org.sonatype.central</groupId>
+                        <artifactId>central-publishing-maven-plugin</artifactId>
+                        <version>0.4.0</version>
                         <extensions>true</extensions>
                         <configuration>
-                            <serverId>ossrh</serverId>
-                            <nexusUrl>https://s01.oss.sonatype.org/</nexusUrl>
-                            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+                            <publishingServerId>central</publishingServerId>
+                            <tokenAuth>true</tokenAuth>
+                            <autoPublish>true</autoPublish>
                         </configuration>
                     </plugin>
                 </plugins>


### PR DESCRIPTION
This PR updates POM config and release workflows to migrate from OSSRH to central publisher portal

## Why
- OSSRH portal is shut down, so we need to migrate to central publisher portal

## Goal
- The release pipelines should not break and we successfully migrate from OSSRH to central publisher portal
