### PR TITLE
SK-2286 take vault url from env and override

### DIFF
--- a/common/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/common/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -16,6 +16,7 @@ public enum ErrorMessage {
     EmptyVaultId("%s0 Initialization failed. Invalid vault ID. Vault ID must not be empty."),
     InvalidClusterId("%s0 Initialization failed. Invalid cluster ID. Specify cluster ID."),
     EmptyClusterId("%s0 Initialization failed. Invalid cluster ID. Specify a valid cluster ID."),
+    EmptyVaultUrl("%s0 Initialization failed. Vault URL is empty. Specify a valid vault URL."),
 
     // Connection config
     InvalidConnectionId("%s0 Initialization failed. Invalid connection ID. Specify a valid connection ID."),
@@ -73,6 +74,7 @@ public enum ErrorMessage {
     InsufficientTokensPassedForTokenModeEnableStrict("%s0 Validation error. 'tokenMode' is set to 'ENABLE_STRICT', but some fields are missing tokens. Specify tokens for all fields."),
     BatchInsertPartialSuccess("%s0 Insert operation completed with partial success."),
     BatchInsertFailure("%s0 Insert operation failed."),
+    RecordSizeExceedError("%s0 Maximum number of records exceeded. The limit is 10000."),
 
     // Detokenize
     InvalidDetokenizeData("%s0 Validation error. Invalid detokenize data. Specify valid detokenize data."),

--- a/common/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/common/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -17,6 +17,7 @@ public enum ErrorMessage {
     InvalidClusterId("%s0 Initialization failed. Invalid cluster ID. Specify cluster ID."),
     EmptyClusterId("%s0 Initialization failed. Invalid cluster ID. Specify a valid cluster ID."),
     EmptyVaultUrl("%s0 Initialization failed. Vault URL is empty. Specify a valid vault URL."),
+    InvalidVaultUrlFormat("%s0 Initialization failed. Vault URL must start with 'https://'."),
 
     // Connection config
     InvalidConnectionId("%s0 Initialization failed. Invalid connection ID. Specify a valid connection ID."),

--- a/common/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/common/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -81,6 +81,7 @@ public enum ErrorMessage {
     InvalidDetokenizeData("%s0 Validation error. Invalid detokenize data. Specify valid detokenize data."),
     EmptyDetokenizeData("%s0 Validation error. Invalid data tokens. Specify at least one data token."),
     EmptyTokenInDetokenizeData("%s0 Validation error. Invalid data tokens. Specify a valid data token."),
+    TokensSizeExceedError("%s0 Maximum number of tokens exceeded. The limit is 10000."),
 
     // Get
     IdsKeyError("%s0 Validation error. 'ids' key is missing from the payload. Specify an 'ids' key."),

--- a/common/src/main/java/com/skyflow/utils/BaseUtils.java
+++ b/common/src/main/java/com/skyflow/utils/BaseUtils.java
@@ -51,6 +51,8 @@ public class BaseUtils {
             String vaultURL = dotenv.get("VAULT_URL");
             if (vaultURL != null && vaultURL.trim().isEmpty()) {
                 throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyVaultUrl.getMessage());
+            } else if (vaultURL != null && !vaultURL.startsWith(BaseConstants.SECURE_PROTOCOL)) {
+                throw new SkyflowException( ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidVaultUrlFormat.getMessage());
             }
             return vaultURL;
         } catch (DotenvException e) {

--- a/common/src/main/java/com/skyflow/utils/BaseUtils.java
+++ b/common/src/main/java/com/skyflow/utils/BaseUtils.java
@@ -11,6 +11,8 @@ import com.skyflow.logs.InfoLogs;
 import com.skyflow.serviceaccount.util.BearerToken;
 import com.skyflow.serviceaccount.util.Token;
 import com.skyflow.utils.logger.LogUtil;
+import io.github.cdimascio.dotenv.Dotenv;
+import io.github.cdimascio.dotenv.DotenvException;
 import org.apache.commons.codec.binary.Base64;
 
 import java.io.File;
@@ -41,6 +43,21 @@ public class BaseUtils {
                 break;
         }
         return sb.toString();
+    }
+
+    public static String getEnvVaultURL() {
+        try {
+            Dotenv dotenv = Dotenv.load();
+            String vaultURL = dotenv.get("VAULT_URL");
+            if (vaultURL != null && vaultURL.trim().isEmpty()) {
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyVaultUrl.getMessage());
+            }
+            return vaultURL;
+        } catch (DotenvException e) {
+            return null;
+        } catch (SkyflowException e) {
+           throw new RuntimeException(e);
+        }
     }
 
     public static String generateBearerToken(Credentials credentials) throws SkyflowException {

--- a/common/src/main/java/com/skyflow/utils/validations/BaseValidations.java
+++ b/common/src/main/java/com/skyflow/utils/validations/BaseValidations.java
@@ -28,12 +28,14 @@ public class BaseValidations {
         } else if (vaultId.trim().isEmpty()) {
             LogUtil.printErrorLog(ErrorLogs.EMPTY_VAULT_ID.getLog());
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyVaultId.getMessage());
-        } else if (clusterId == null) {
-            LogUtil.printErrorLog(ErrorLogs.CLUSTER_ID_IS_REQUIRED.getLog());
-            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidClusterId.getMessage());
-        } else if (clusterId.trim().isEmpty()) {
-            LogUtil.printErrorLog(ErrorLogs.EMPTY_CLUSTER_ID.getLog());
-            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyClusterId.getMessage());
+        } else if (BaseUtils.getEnvVaultURL() == null) {
+            if (clusterId == null) {
+                LogUtil.printErrorLog(ErrorLogs.CLUSTER_ID_IS_REQUIRED.getLog());
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidClusterId.getMessage());
+            } else if (clusterId.trim().isEmpty()) {
+                LogUtil.printErrorLog(ErrorLogs.EMPTY_CLUSTER_ID.getLog());
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyClusterId.getMessage());
+            }
         } else if (credentials != null) {
             validateCredentials(credentials);
         }

--- a/v3/src/main/java/com/skyflow/VaultClient.java
+++ b/v3/src/main/java/com/skyflow/VaultClient.java
@@ -80,7 +80,10 @@ public class VaultClient {
     }
 
     private void updateVaultURL() {
-        String vaultURL = Utils.getVaultURL(this.vaultConfig.getClusterId(), this.vaultConfig.getEnv());
+        String vaultURL = Utils.getEnvVaultURL();
+        if (vaultURL == null || vaultURL.isEmpty()) {
+            vaultURL = Utils.getVaultURL(this.vaultConfig.getClusterId(), this.vaultConfig.getEnv());
+        }
         this.apiClientBuilder.url(vaultURL);
     }
 

--- a/v3/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/v3/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -46,6 +46,8 @@ public class Validations extends BaseValidations {
                     ErrorLogs.EMPTY_VALUES.getLog(), InterfaceName.INSERT.getName()
             ));
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyValues.getMessage());
+        } else if(values.size() > 10000) {
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.RecordSizeExceedError.getMessage());
         } else if (upsert != null && upsert.isEmpty()){
             LogUtil.printErrorLog(Utils.parameterizedString(
                     ErrorLogs.EMPTY_UPSERT.getLog(), InterfaceName.INSERT.getName()

--- a/v3/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/v3/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -84,6 +84,9 @@ public class Validations extends BaseValidations {
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.DetokenizeRequestNull.getMessage());
         }
         List<String> tokens = request.getTokens();
+        if(tokens.size() > 10000) {
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.TokensSizeExceedError.getMessage());
+        }
         if (tokens == null || tokens.isEmpty()) {
             LogUtil.printErrorLog(Utils.parameterizedString(
                     ErrorLogs.EMPTY_DETOKENIZE_DATA.getLog(), InterfaceName.DETOKENIZE.getName()


### PR DESCRIPTION
To pass vault url from the env variables
## Why
- Currently only cluster id and env are passed and the url will be constructed with these values
- But there is no feasibility to pass vault url directly
- So  made code changes to take it from the env variables and override the one that is constructed by cluster id

## Goal
- The url passed from env variables should override the one that is constructed with cluster id

## Testing
- tested in local