### PR TITLE
SK-2289 Fix upsert operation not working issue

### DIFF
--- a/common/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/common/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -68,6 +68,7 @@ public enum ErrorMessage {
     EmptyKeyInTokens("%s0 Validation error. Invalid key tokens. Specify a valid key."),
     EmptyValueInTokens("%s0 Validation error. Invalid value in tokens. Specify a valid value."),
     EmptyUpsert("%s0 Validation error. 'upsert' key can't be empty. Specify an upsert column."),
+    EmptyUpsertValues("%s0 Validation error. Upsert column values can't be empty. Specify at least one upsert column."),
     HomogenousNotSupportedWithUpsert("%s0 Validation error. 'homogenous' is not supported with 'upsert'. Specify either 'homogenous' or 'upsert'."),
     TokensPassedForTokenModeDisable("%s0 Validation error. 'tokenMode' wasn't specified. Set 'tokenMode' to 'ENABLE' to insert tokens."),
     NoTokensWithTokenMode("%s0 Validation error. Tokens weren't specified for records while 'tokenMode' was %s1. Specify tokens."),

--- a/common/src/main/java/com/skyflow/logs/ErrorLogs.java
+++ b/common/src/main/java/com/skyflow/logs/ErrorLogs.java
@@ -56,6 +56,7 @@ public enum ErrorLogs {
     EMPTY_OR_NULL_VALUE_IN_VALUES("Invalid %s1 request. Value can not be null or empty in values for key \"%s2\"."),
     EMPTY_OR_NULL_KEY_IN_VALUES("Invalid %s1 request. Key can not be null or empty in values"),
     EMPTY_UPSERT("Invalid %s1 request. Upsert can not be empty."),
+    EMPTY_UPSERT_VALUES("Invalid %s1 request. Upsert values can not be empty."),
     HOMOGENOUS_NOT_SUPPORTED_WITH_UPSERT("Invalid %s1 request. Homogenous is not supported when upsert is passed."),
     TOKENS_NOT_ALLOWED_WITH_TOKEN_MODE_DISABLE("Invalid %s1 request. Tokens are not allowed when tokenMode is DISABLE."),
     TOKENS_REQUIRED_WITH_TOKEN_MODE("Invalid %s1 request. Tokens are required when tokenMode is %s2."),

--- a/v3/src/main/java/com/skyflow/VaultClient.java
+++ b/v3/src/main/java/com/skyflow/VaultClient.java
@@ -131,6 +131,7 @@ public class VaultClient {
                 .build();
         apiClientBuilder.httpClient(httpClient);
     }
+
     protected InsertRequest getBulkInsertRequestBody(com.skyflow.vault.data.InsertRequest request, VaultConfig config) throws SkyflowException {
         List<HashMap<String, Object>> values = request.getValues();
         List<InsertRecordData> insertRecordDataList = new ArrayList<>();
@@ -142,12 +143,12 @@ public class VaultClient {
                 .vaultId(config.getVaultId())
                 .records(insertRecordDataList)
                 .tableName(request.getTable());
-        if(request.getUpsert() != null && !request.getUpsert().isEmpty()){
+        if (request.getUpsert() != null && !request.getUpsert().isEmpty()) {
             if (request.getUpsertType() != null) {
                 EnumUpdateType updateType = null;
-                if(request.getUpsertType() == UpdateType.REPLACE){
+                if (request.getUpsertType() == UpdateType.REPLACE) {
                     updateType = EnumUpdateType.REPLACE;
-                } else if (request.getUpsertType() == UpdateType.REPLACE) {
+                } else if (request.getUpsertType() == UpdateType.UPDATE) {
                     updateType = EnumUpdateType.UPDATE;
                 }
                 Upsert upsert = Upsert.builder().uniqueColumns(request.getUpsert()).updateType(updateType).build();
@@ -167,7 +168,7 @@ public class VaultClient {
                 com.skyflow.generated.rest.resources.recordservice.requests.DetokenizeRequest.builder()
                         .vaultId(this.vaultConfig.getVaultId())
                         .tokens(tokens);
-        if (request.getTokenGroupRedactions() != null){
+        if (request.getTokenGroupRedactions() != null) {
             List<com.skyflow.generated.rest.types.TokenGroupRedactions> tokenGroupRedactionsList = new ArrayList<>();
             for (com.skyflow.vault.data.TokenGroupRedactions tokenGroupRedactions : request.getTokenGroupRedactions()) {
                 com.skyflow.generated.rest.types.TokenGroupRedactions redactions =

--- a/v3/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/v3/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -7,7 +7,6 @@ import com.skyflow.errors.ErrorCode;
 import com.skyflow.errors.ErrorMessage;
 import com.skyflow.errors.SkyflowException;
 import com.skyflow.logs.ErrorLogs;
-import com.skyflow.utils.BaseUtils;
 import com.skyflow.utils.Utils;
 import com.skyflow.utils.logger.LogUtil;
 import com.skyflow.vault.data.DetokenizeRequest;
@@ -23,7 +22,6 @@ public class Validations extends BaseValidations {
         super();
     }
 
-    // add validations specific to v3 SDK
     public static void validateInsertRequest(InsertRequest insertRequest) throws SkyflowException {
         String table = insertRequest.getTable();
         ArrayList<HashMap<String, Object>> values = insertRequest.getValues();
@@ -49,15 +47,15 @@ public class Validations extends BaseValidations {
                     ErrorLogs.EMPTY_VALUES.getLog(), InterfaceName.INSERT.getName()
             ));
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyValues.getMessage());
-        } else if(values.size() > 10000) {
+        } else if (values.size() > 10000) {
             LogUtil.printErrorLog(ErrorLogs.RECORD_SIZE_EXCEED.getLog());
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.RecordSizeExceedError.getMessage());
-        } else if (upsert != null && upsert.isEmpty()){
+        } else if (upsert != null && upsert.isEmpty()) {
             LogUtil.printErrorLog(Utils.parameterizedString(
-                    ErrorLogs.EMPTY_UPSERT.getLog(), InterfaceName.INSERT.getName()
+                    ErrorLogs.EMPTY_UPSERT_VALUES.getLog(), InterfaceName.INSERT.getName()
             ));
+            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyUpsertValues.getMessage());
         }
-        // upsert
 
         for (HashMap<String, Object> valuesMap : values) {
             for (String key : valuesMap.keySet()) {
@@ -88,7 +86,7 @@ public class Validations extends BaseValidations {
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.DetokenizeRequestNull.getMessage());
         }
         List<String> tokens = request.getTokens();
-        if(tokens.size() > 10000) {
+        if (tokens.size() > 10000) {
             LogUtil.printErrorLog(ErrorLogs.TOKENS_SIZE_EXCEED.getLog());
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.TokensSizeExceedError.getMessage());
         }

--- a/v3/test/java/com/skyflow/vault/data/InsertTests.java
+++ b/v3/test/java/com/skyflow/vault/data/InsertTests.java
@@ -211,11 +211,11 @@ public class InsertTests {
         InsertRequest request = InsertRequest.builder().table(table).values(values).upsert(new ArrayList<>()).build();
         try {
             Validations.validateInsertRequest(request);
-//            Assert.fail(EXCEPTION_NOT_THROWN);
+            Assert.fail(EXCEPTION_NOT_THROWN);
         } catch (SkyflowException e) {
             Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
             Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.EmptyUpsert.getMessage(), Constants.SDK_PREFIX),
+                    Utils.parameterizedString(ErrorMessage.EmptyUpsertValues.getMessage(), Constants.SDK_PREFIX),
                     e.getMessage()
             );
         }


### PR DESCRIPTION
This PR fixes the issue where upsert operation was not working as expected even when upsert related options were passed in insert request. 
## Why
- If upsert options are passed, then upsert operation should take place for records that match upsert critieria.

## Goal
- When upsert options are passed, then upsert operation will take place for records that match upsert critieria.

## Testing
- Tested the changes manually for upsert and verified that upsert operation is taking place.

