### PR TITLE
SK-2315 add version as prefix to logs

### DIFF
--- a/v3/pom.xml
+++ b/v3/pom.xml
@@ -35,6 +35,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <sdk.version>${project.version}</sdk.version>
     </properties>
 
 
@@ -48,6 +49,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/v3/src/main/java/com/skyflow/utils/Constants.java
+++ b/v3/src/main/java/com/skyflow/utils/Constants.java
@@ -1,10 +1,14 @@
 package com.skyflow.utils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public final class Constants extends BaseConstants {
     public static final String SDK_NAME = "Skyflow Java SDK ";
-    public static final String SDK_VERSION = "3.0.0-beta.6";
+    public static final String SDK_VERSION;
     public static final String VAULT_DOMAIN = ".skyvault.";
-    public static final String SDK_PREFIX = SDK_NAME + SDK_VERSION;
+    public static final String SDK_PREFIX;
     public static final Integer INSERT_BATCH_SIZE = 50;
     public static final Integer MAX_INSERT_BATCH_SIZE = 1000;
     public static final Integer INSERT_CONCURRENCY_LIMIT = 1;
@@ -13,5 +17,24 @@ public final class Constants extends BaseConstants {
     public static final Integer DETOKENIZE_CONCURRENCY_LIMIT = 1;
     public static final Integer MAX_DETOKENIZE_BATCH_SIZE = 1000;
     public static final Integer MAX_DETOKENIZE_CONCURRENCY_LIMIT = 10;
+    public static final String DEFAULT_SDK_VERSION = "v3";
+
+    static {
+        String sdkVersion;
+        // Use a static initializer block to read the properties file
+        Properties properties = new Properties();
+        try (InputStream input = Constants.class.getClassLoader().getResourceAsStream("sdk.properties")) {
+            if (input == null) {
+                sdkVersion = DEFAULT_SDK_VERSION;
+            } else {
+                properties.load(input);
+                sdkVersion = properties.getProperty("sdk.version", DEFAULT_SDK_VERSION);
+            }
+        } catch (IOException ex) {
+            sdkVersion = DEFAULT_SDK_VERSION;
+        }
+        SDK_VERSION = sdkVersion;
+        SDK_PREFIX = SDK_NAME + " " + SDK_VERSION;
+    }
 
 }

--- a/v3/src/main/resources/sdk.properties
+++ b/v3/src/main/resources/sdk.properties
@@ -1,0 +1,1 @@
+sdk.version=${sdk.version}


### PR DESCRIPTION

## Why
- To get the SDK version as prefix for the logs
- The version was dynamically hard coded before in constants file
- Now we get it from the project metadata

## Goal
- The logs should have the Skyflow Java version as prefix