### PR TITLE
SK-2315 add version as prefix to logs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,7 +1,7 @@
 name: Public release
 on:
   push:
-    tags: '*.*.*'
+    tags: '[0-9]+.[0-9]+.[0-9]+'
 jobs:
   build-and-deploy:
     uses: ./.github/workflows/shared-build-and-deploy.yml

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.skyflow</groupId>
             <artifactId>skyflow-java</artifactId>
-            <version>3.0.0-beta.3</version>
+            <version>3.0.0-beta.6</version>
         </dependency>
 
     </dependencies>

--- a/samples/src/main/java/com/example/vault/BulkInsertAsync.java
+++ b/samples/src/main/java/com/example/vault/BulkInsertAsync.java
@@ -5,7 +5,7 @@ import com.skyflow.config.Credentials;
 import com.skyflow.config.VaultConfig;
 import com.skyflow.enums.Env;
 import com.skyflow.enums.LogLevel;
-import com.skyflow.enums.UpdateType;
+import com.skyflow.enums.UpsertType;
 import com.skyflow.vault.data.InsertRecord;
 import com.skyflow.vault.data.InsertRequest;
 import com.skyflow.vault.data.InsertResponse;
@@ -77,7 +77,7 @@ public class BulkInsertAsync {
             InsertRequest request = InsertRequest.builder()
                     .table("<YOUR_TABLE_NAME>")
                     .upsert(upsertColumns)
-                    .upsertType(UpdateType.REPLACE)
+                    .upsertType(UpsertType.REPLACE)
                     .records(insertRecords)
                     .build();
 

--- a/samples/src/main/java/com/example/vault/BulkInsertSync.java
+++ b/samples/src/main/java/com/example/vault/BulkInsertSync.java
@@ -5,8 +5,9 @@ import com.skyflow.config.Credentials;
 import com.skyflow.config.VaultConfig;
 import com.skyflow.enums.Env;
 import com.skyflow.enums.LogLevel;
-import com.skyflow.enums.UpdateType;
+import com.skyflow.enums.UpsertType;
 import com.skyflow.errors.SkyflowException;
+import com.skyflow.vault.data.InsertRecord;
 import com.skyflow.vault.data.InsertRequest;
 import com.skyflow.vault.data.InsertResponse;
 
@@ -76,7 +77,7 @@ public class BulkInsertSync {
             InsertRequest request = InsertRequest.builder()
                     .table("<YOUR_TABLE_NAME>")
                     .upsert(upsertColumns)
-                    .upsertType(UpdateType.REPLACE)
+                    .upsertType(UpsertType.REPLACE)
                     .records(insertRecords)
                     .build();
 

--- a/samples/src/main/java/com/example/vault/BulkMultiTableInsertAsync.java
+++ b/samples/src/main/java/com/example/vault/BulkMultiTableInsertAsync.java
@@ -5,7 +5,7 @@ import com.skyflow.config.Credentials;
 import com.skyflow.config.VaultConfig;
 import com.skyflow.enums.Env;
 import com.skyflow.enums.LogLevel;
-import com.skyflow.enums.UpdateType;
+import com.skyflow.enums.UpsertType;
 import com.skyflow.vault.data.InsertRecord;
 import com.skyflow.vault.data.InsertRequest;
 import com.skyflow.vault.data.InsertResponse;
@@ -48,7 +48,7 @@ public class BulkMultiTableInsertAsync {
 
             // Step 4: Prepare first record for insertion
             HashMap<String, Object> recordData1 = new HashMap<>();
-            rerecordData1cord1.put("<YOUR_COLUMN_NAME_1>", "<YOUR_VALUE_1>");
+            recordData1.put("<YOUR_COLUMN_NAME_1>", "<YOUR_VALUE_1>");
             recordData1.put("<YOUR_COLUMN_NAME_2>", "<YOUR_VALUE_1>");
 
             List<String> upsertColumns = new ArrayList<>();

--- a/samples/src/main/java/com/example/vault/BulkMultiTableInsertSync.java
+++ b/samples/src/main/java/com/example/vault/BulkMultiTableInsertSync.java
@@ -5,8 +5,9 @@ import com.skyflow.config.Credentials;
 import com.skyflow.config.VaultConfig;
 import com.skyflow.enums.Env;
 import com.skyflow.enums.LogLevel;
-import com.skyflow.enums.UpdateType;
+import com.skyflow.enums.UpsertType;
 import com.skyflow.errors.SkyflowException;
+import com.skyflow.vault.data.InsertRecord;
 import com.skyflow.vault.data.InsertRequest;
 import com.skyflow.vault.data.InsertResponse;
 
@@ -46,7 +47,7 @@ public class BulkMultiTableInsertSync {
 
             // Step 4: Prepare first record for insertion
             HashMap<String, Object> recordData1 = new HashMap<>();
-            rerecordData1cord1.put("<YOUR_COLUMN_NAME_1>", "<YOUR_VALUE_1>");
+            recordData1.put("<YOUR_COLUMN_NAME_1>", "<YOUR_VALUE_1>");
             recordData1.put("<YOUR_COLUMN_NAME_2>", "<YOUR_VALUE_1>");
 
             List<String> upsertColumns = new ArrayList<>();

--- a/v3/pom.xml
+++ b/v3/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>skyflow-java</artifactId>
-    <version>3.0.0-beta.6-dev.29215f7</version>
+    <version>3.0.0-beta.6-dev.4dec765</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Skyflow V3 SDK for the Java programming language</description>

--- a/v3/pom.xml
+++ b/v3/pom.xml
@@ -11,7 +11,7 @@
     </parent>
 
     <artifactId>skyflow-java</artifactId>
-    <version>3.0.0-beta.6</version>
+    <version>3.0.0-beta.6-dev.29215f7</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
     <description>Skyflow V3 SDK for the Java programming language</description>

--- a/v3/pom.xml
+++ b/v3/pom.xml
@@ -35,6 +35,7 @@
         <maven.compiler.target>8</maven.compiler.target>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.deploy.skip>false</maven.deploy.skip>
+        <sdk.version>${project.version}</sdk.version>
     </properties>
 
 
@@ -48,6 +49,12 @@
     </dependencies>
 
     <build>
+        <resources>
+            <resource>
+                <directory>src/main/resources</directory>
+                <filtering>true</filtering>
+            </resource>
+        </resources>
         <plugins>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/v3/src/main/java/com/skyflow/utils/Constants.java
+++ b/v3/src/main/java/com/skyflow/utils/Constants.java
@@ -1,10 +1,14 @@
 package com.skyflow.utils;
 
+import java.io.IOException;
+import java.io.InputStream;
+import java.util.Properties;
+
 public final class Constants extends BaseConstants {
     public static final String SDK_NAME = "Skyflow Java SDK ";
-    public static final String SDK_VERSION = "3.0.0-beta.6";
+    public static final String SDK_VERSION;
     public static final String VAULT_DOMAIN = ".skyvault.";
-    public static final String SDK_PREFIX = SDK_NAME + SDK_VERSION;
+    public static final String SDK_PREFIX;
     public static final Integer INSERT_BATCH_SIZE = 50;
     public static final Integer MAX_INSERT_BATCH_SIZE = 1000;
     public static final Integer INSERT_CONCURRENCY_LIMIT = 1;
@@ -13,5 +17,24 @@ public final class Constants extends BaseConstants {
     public static final Integer DETOKENIZE_CONCURRENCY_LIMIT = 1;
     public static final Integer MAX_DETOKENIZE_BATCH_SIZE = 1000;
     public static final Integer MAX_DETOKENIZE_CONCURRENCY_LIMIT = 10;
+    public static final String DEFAULT_SDK_VERSION = "v3";
+
+    static {
+        String sdkVersion;
+        // Use a static initializer block to read the properties file
+        Properties properties = new Properties();
+        try (InputStream input = Constants.class.getClassLoader().getResourceAsStream("sdk.properties")) {
+            if (input == null) {
+                sdkVersion = DEFAULT_SDK_VERSION;
+            } else {
+                properties.load(input);
+                sdkVersion = properties.getProperty("sdk.version", DEFAULT_SDK_VERSION);
+            }
+        } catch (IOException ex) {
+            sdkVersion = DEFAULT_SDK_VERSION;
+        }
+        SDK_VERSION = sdkVersion;
+        SDK_PREFIX = SDK_NAME + " " + SDK_VERSION;
+    }
 
 }

--- a/v3/src/main/resources/sdk.properties
+++ b/v3/src/main/resources/sdk.properties
@@ -1,0 +1,1 @@
+sdk.version=${sdk.version}


### PR DESCRIPTION
## Why
- To get the SDK version as prefix for the logs
- The version was dynamically hard coded before in constants file
- Now we get it from the project metadata

## Goal
- The logs should have the Skyflow Java version as prefix