### PR TITLE
SK-2473: allow null and empty field values in insert and update valid…

### DIFF
--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -291,15 +291,6 @@ public class Validations {
                             ErrorLogs.EMPTY_OR_NULL_KEY_IN_VALUES.getLog(), InterfaceName.INSERT.getName()
                     ));
                     throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyKeyInValues.getMessage());
-                } else {
-                    Object value = valuesMap.get(key);
-                    if (value == null || value.toString().trim().isEmpty()) {
-                        LogUtil.printErrorLog(Utils.parameterizedString(
-                                ErrorLogs.EMPTY_OR_NULL_VALUE_IN_VALUES.getLog(),
-                                InterfaceName.INSERT.getName(), key
-                        ));
-                        throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyValueInValues.getMessage());
-                    }
                 }
             }
         }
@@ -541,15 +532,6 @@ public class Validations {
                         ErrorLogs.EMPTY_OR_NULL_KEY_IN_VALUES.getLog(), InterfaceName.UPDATE.getName()
                 ));
                 throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyKeyInValues.getMessage());
-            } else {
-                Object value = data.get(key);
-                if (value == null || value.toString().trim().isEmpty()) {
-                    LogUtil.printErrorLog(Utils.parameterizedString(
-                            ErrorLogs.EMPTY_OR_NULL_VALUE_IN_VALUES.getLog(), InterfaceName.UPDATE.getName(), key
-                    ));
-                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(),
-                            ErrorMessage.EmptyValueInValues.getMessage());
-                }
             }
         }
 

--- a/src/test/java/com/skyflow/vault/data/InsertTests.java
+++ b/src/test/java/com/skyflow/vault/data/InsertTests.java
@@ -210,13 +210,24 @@ public class InsertTests {
         InsertRequest request = InsertRequest.builder().table(table).values(values).build();
         try {
             Validations.validateInsertRequest(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
+            Assert.assertEquals(table, request.getTable());
+            Assert.assertEquals(1, request.getValues().size());
         } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.EmptyValueInValues.getMessage(), Constants.SDK_PREFIX),
-                    e.getMessage()
-            );
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testNullValueInValuesInInsertRequestValidations() {
+        valueMap.put("test_column_3", null);
+        values.add(valueMap);
+        InsertRequest request = InsertRequest.builder().table(table).values(values).build();
+        try {
+            Validations.validateInsertRequest(request);
+            Assert.assertEquals(table, request.getTable());
+            Assert.assertEquals(1, request.getValues().size());
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
         }
     }
 

--- a/src/test/java/com/skyflow/vault/data/UpdateTests.java
+++ b/src/test/java/com/skyflow/vault/data/UpdateTests.java
@@ -248,25 +248,6 @@ public class UpdateTests {
     }
 
     @Test
-    public void testNullValueInValuesInUpdateRequestValidations() {
-        dataMap.put("skyflow_id", skyflowID);
-        dataMap.put("test_column_1", "test_value_1");
-        dataMap.put("test_column_2", "test_value_2");
-        dataMap.put("test_column_3", null);
-        UpdateRequest request = UpdateRequest.builder().table(table).data(dataMap).build();
-        try {
-            Validations.validateUpdateRequest(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
-        } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.EmptyValueInValues.getMessage(), Constants.SDK_PREFIX),
-                    e.getMessage()
-            );
-        }
-    }
-
-    @Test
     public void testEmptyValueInValuesInUpdateRequestValidations() {
         dataMap.put("skyflow_id", skyflowID);
         dataMap.put("test_column_1", "test_value_1");
@@ -275,13 +256,26 @@ public class UpdateTests {
         UpdateRequest request = UpdateRequest.builder().table(table).data(dataMap).build();
         try {
             Validations.validateUpdateRequest(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
+            Assert.assertEquals(table, request.getTable());
+            Assert.assertEquals(4, request.getData().size());
         } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.EmptyValueInValues.getMessage(), Constants.SDK_PREFIX),
-                    e.getMessage()
-            );
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testNullValueInValuesInUpdateRequestValidations() {
+        dataMap.put("skyflow_id", skyflowID);
+        dataMap.put("test_column_1", "test_value_1");
+        dataMap.put("test_column_2", "test_value_2");
+        dataMap.put("test_column_3", null);
+        UpdateRequest request = UpdateRequest.builder().table(table).data(dataMap).build();
+        try {
+            Validations.validateUpdateRequest(request);
+            Assert.assertEquals(table, request.getTable());
+            Assert.assertEquals(4, request.getData().size());
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
         }
     }
 


### PR DESCRIPTION
## Why
Null or empty values are not allowed in records object in java v2 sdk, if null or empty value is passed it throw the validation error.

## Goal
Allow null and empty string values for record fields in insert and update requests.

## Testing
Updated and added unit tests to cover null field values and empty string field values for insert and update requests tests.