### PR TITLE
SK-2594: Update skyflow-java version to 2.0.3 in samples

### DIFF
--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.skyflow</groupId>
             <artifactId>skyflow-java</artifactId>
-            <version>2.0.0</version>
+            <version>2.0.3</version>
         </dependency>
 
     </dependencies>


### PR DESCRIPTION
**Why**
- Fixed a severe vulnerability in 2.0.3 version

**Outcome**
- Use updated skyflow-java version which doesn't have vulnerabilities