### PR TITLE
SK-2645: Allow null and empty field values in insert and update

### DIFF
--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -313,15 +313,6 @@ public class Validations {
                             ErrorLogs.EMPTY_OR_NULL_KEY_IN_VALUES.getLog(), InterfaceName.INSERT.getName()
                     ));
                     throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyKeyInValues.getMessage());
-                } else {
-                    Object value = valuesMap.get(key);
-                    if (value == null || value.toString().trim().isEmpty()) {
-                        LogUtil.printErrorLog(Utils.parameterizedString(
-                                ErrorLogs.EMPTY_OR_NULL_VALUE_IN_VALUES.getLog(),
-                                InterfaceName.INSERT.getName(), key
-                        ));
-                        throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyValueInValues.getMessage());
-                    }
                 }
             }
         }
@@ -563,15 +554,6 @@ public class Validations {
                         ErrorLogs.EMPTY_OR_NULL_KEY_IN_VALUES.getLog(), InterfaceName.UPDATE.getName()
                 ));
                 throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyKeyInValues.getMessage());
-            } else {
-                Object value = data.get(key);
-                if (value == null || value.toString().trim().isEmpty()) {
-                    LogUtil.printErrorLog(Utils.parameterizedString(
-                            ErrorLogs.EMPTY_OR_NULL_VALUE_IN_VALUES.getLog(), InterfaceName.UPDATE.getName(), key
-                    ));
-                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(),
-                            ErrorMessage.EmptyValueInValues.getMessage());
-                }
             }
         }
 

--- a/src/test/java/com/skyflow/vault/data/InsertTests.java
+++ b/src/test/java/com/skyflow/vault/data/InsertTests.java
@@ -210,29 +210,24 @@ public class InsertTests {
         InsertRequest request = InsertRequest.builder().table(table).values(values).build();
         try {
             Validations.validateInsertRequest(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
+            Assert.assertEquals(table, request.getTable());
+            Assert.assertEquals(1, request.getValues().size());
         } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.EmptyValueInValues.getMessage(), Constants.SDK_PREFIX),
-                    e.getMessage()
-            );
+            Assert.fail(INVALID_EXCEPTION_THROWN);
         }
     }
 
     @Test
-    public void testEmptyUpsertInInsertRequestValidations() {
+    public void testNullValueInValuesInInsertRequestValidations() {
+        valueMap.put("test_column_3", null);
         values.add(valueMap);
-        InsertRequest request = InsertRequest.builder().table(table).values(values).upsert("").build();
+        InsertRequest request = InsertRequest.builder().table(table).values(values).build();
         try {
             Validations.validateInsertRequest(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
+            Assert.assertEquals(table, request.getTable());
+            Assert.assertEquals(1, request.getValues().size());
         } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.EmptyUpsert.getMessage(), Constants.SDK_PREFIX),
-                    e.getMessage()
-            );
+            Assert.fail(INVALID_EXCEPTION_THROWN);
         }
     }
 

--- a/src/test/java/com/skyflow/vault/data/UpdateTests.java
+++ b/src/test/java/com/skyflow/vault/data/UpdateTests.java
@@ -256,13 +256,10 @@ public class UpdateTests {
         UpdateRequest request = UpdateRequest.builder().table(table).data(dataMap).build();
         try {
             Validations.validateUpdateRequest(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
+            Assert.assertEquals(table, request.getTable());
+            Assert.assertEquals(4, request.getData().size());
         } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.EmptyValueInValues.getMessage(), Constants.SDK_PREFIX),
-                    e.getMessage()
-            );
+            Assert.fail(INVALID_EXCEPTION_THROWN);
         }
     }
 
@@ -275,13 +272,10 @@ public class UpdateTests {
         UpdateRequest request = UpdateRequest.builder().table(table).data(dataMap).build();
         try {
             Validations.validateUpdateRequest(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
+            Assert.assertEquals(table, request.getTable());
+            Assert.assertEquals(4, request.getData().size());
         } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.EmptyValueInValues.getMessage(), Constants.SDK_PREFIX),
-                    e.getMessage()
-            );
+            Assert.fail(INVALID_EXCEPTION_THROWN);
         }
     }
 


### PR DESCRIPTION
## Why
Null or empty values are not allowed in records object in java v2 sdk, if null or empty value is passed it throw the validation error.

## Goal
Allow null and empty string values for record fields in insert and update requests.

## Testing
Updated and added unit tests to cover null field values and empty string field values for insert and update requests tests.