### PR TITLE
feat: add JSON object support for ctx in token generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -2771,73 +2771,59 @@ public class BearerTokenGenerationExample {
 
 ## Generate bearer tokens with context
 
-**Context-aware authorization** embeds context values into a bearer token during its generation and so you can reference those values in your policies. This enables more flexible access controls, such as helping you track end-user identity when making API calls using service accounts, and facilitates using signed data tokens during detokenization. .
+**Context-aware authorization** embeds context values into a bearer token during its generation so you can reference those values in your policies. This enables more flexible access controls, such as helping you track end-user identity when making API calls using service accounts, and facilitates using signed data tokens during detokenization.
 
 A service account with the `context_id` identifier generates bearer tokens containing context information, represented as a JWT claim in a Skyflow-generated bearer token. Tokens generated from such service accounts include a `context_identifier` claim, are valid for 60 minutes, and can be used to make API calls to the Data and Management APIs, depending on the service account's permissions.
 
-[Example](https://github.com/skyflowapi/skyflow-java/blob/main/samples/src/main/java/com/example/serviceaccount/BearerTokenGenerationWithContextExample.java):
+The `setCtx()` method accepts either a **String** or a **`Map<String, Object>`**:
+
+**String context** — use when your policy references a single context value:
 
 ```java
-import com.skyflow.errors.SkyflowException;
-import com.skyflow.serviceaccount.util.BearerToken;
-
-import java.io.File;
-
-/**
- * Example program to generate a Bearer Token using Skyflow's BearerToken utility.
- * The token is generated using two approaches:
- * 1. By providing the credentials.json file path.
- * 2. By providing the contents of credentials.json as a string.
- */
-public class BearerTokenGenerationWithContextExample {
-    public static void main(String[] args) {
-        // Variable to store the generated Bearer Token
-        String bearerToken = null;
-
-        // Approach 1: Generate Bearer Token by specifying the path to the credentials.json file
-        try {
-            // Replace <YOUR_CREDENTIALS_FILE_PATH> with the full path to your credentials.json file
-            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
-
-            // Create a BearerToken object using the file path
-            BearerToken token = BearerToken.builder()
-                    .setCredentials(new File(filePath)) // Set credentials using a File object
-                    .setCtx("abc") // Set context string (example: "abc")
-                    .build(); // Build the BearerToken object
-
-            // Retrieve the Bearer Token as a string
-            bearerToken = token.getBearerToken();
-
-            // Print the generated Bearer Token to the console
-            System.out.println(bearerToken);
-        } catch (SkyflowException e) {
-            // Handle exceptions specific to Skyflow operations
-            e.printStackTrace();
-        }
-
-        // Approach 2: Generate Bearer Token by specifying the contents of credentials.json as a string
-        try {
-            // Replace <YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING> with the actual contents of your credentials.json file
-            String fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>";
-
-            // Create a BearerToken object using the file contents as a string
-            BearerToken token = BearerToken.builder()
-                    .setCredentials(fileContents) // Set credentials using a string representation of the file
-                    .setCtx("abc") // Set context string (example: "abc")
-                    .build(); // Build the BearerToken object
-
-            // Retrieve the Bearer Token as a string
-            bearerToken = token.getBearerToken();
-
-            // Print the generated Bearer Token to the console
-            System.out.println(bearerToken);
-        } catch (SkyflowException e) {
-            // Handle exceptions specific to Skyflow operations
-            e.printStackTrace();
-        }
-    }
-}
+BearerToken token = BearerToken.builder()
+        .setCredentials(new File(filePath))
+        .setCtx("user_12345")
+        .build();
 ```
+
+**JSON object context** — use when your policy needs multiple context values for conditional data access. Each key in the `Map` maps to a Skyflow CEL policy variable under `request.context.*`:
+
+```java
+Map<String, Object> ctx = new HashMap<>();
+ctx.put("role", "admin");
+ctx.put("department", "finance");
+ctx.put("user_id", "user_12345");
+
+BearerToken token = BearerToken.builder()
+        .setCredentials(new File(filePath))
+        .setCtx(ctx)
+        .build();
+```
+
+With the map above, your Skyflow policies can reference `request.context.role`, `request.context.department`, and `request.context.user_id` to make conditional access decisions.
+
+You can also set context on `Credentials` for automatic token generation:
+
+```java
+// String context
+Credentials credentials = new Credentials();
+credentials.setPath("path/to/credentials.json");
+credentials.setContext("user_12345");
+
+// Map context
+Map<String, Object> ctx = new HashMap<>();
+ctx.put("role", "admin");
+ctx.put("department", "finance");
+credentials.setContext(ctx);
+```
+
+> **Note:** `getContext()` returns `Object` — callers should use `instanceof` if they need to inspect the type.
+
+Context map keys must contain only alphanumeric characters and underscores (`[a-zA-Z0-9_]`). Invalid keys will throw a `SkyflowException`.
+
+[Full example](https://github.com/skyflowapi/skyflow-java/blob/main/samples/src/main/java/com/example/serviceaccount/BearerTokenGenerationWithContextExample.java)
+
+See Skyflow's [context-aware authorization](https://docs.skyflow.com) and [conditional data access](https://docs.skyflow.com) docs for policy variable syntax like `request.context.*`.
 
 ## Generate scoped bearer tokens
 
@@ -2903,58 +2889,31 @@ with the private key of the service account credentials, which adds an additiona
 be detokenized by passing the signed data token and a bearer token generated from service account credentials. The
 service account must have appropriate permissions and context to detokenize the signed data tokens.
 
-[Example](https://github.com/skyflowapi/skyflow-java/blob/main/samples/src/main/java/com/example/serviceaccount/SignedTokenGenerationExample.java):
+The `setCtx()` method on `SignedDataTokensBuilder` also accepts either a **String** or a **`Map<String, Object>`**, using the same format as bearer tokens:
 
 ```java
-import com.skyflow.errors.SkyflowException;
-import com.skyflow.serviceaccount.util.SignedDataTokenResponse;
-import com.skyflow.serviceaccount.util.SignedDataTokens;
+// String context
+SignedDataTokens signedToken = SignedDataTokens.builder()
+        .setCredentials(new File(filePath))
+        .setCtx("user_12345")
+        .setTimeToLive(30)
+        .setDataTokens(dataTokens)
+        .build();
 
-import java.io.File;
-import java.util.ArrayList;
-import java.util.List;
+// JSON object context
+Map<String, Object> ctx = new HashMap<>();
+ctx.put("role", "analyst");
+ctx.put("department", "research");
 
-public class SignedTokenGenerationExample {
-    public static void main(String[] args) {
-        List<SignedDataTokenResponse> signedTokenValues;
-        // Generate Signed data token with context by specifying credentials.json file path
-        try {
-            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
-            String context = "abc";
-            ArrayList<String> dataTokens = new ArrayList<>();
-            dataTokens.add("YOUR_DATA_TOKEN_1");
-            SignedDataTokens signedToken = SignedDataTokens.builder()
-                    .setCredentials(new File(filePath))
-                    .setCtx(context)
-                    .setTimeToLive(30) // in seconds
-                    .setDataTokens(dataTokens)
-                    .build();
-            signedTokenValues = signedToken.getSignedDataTokens();
-            System.out.println(signedTokenValues);
-        } catch (SkyflowException e) {
-            e.printStackTrace();
-        }
-
-        // Generate Signed data token with context by specifying credentials.json as string
-        try {
-            String fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>";
-            String context = "abc";
-            ArrayList<String> dataTokens = new ArrayList<>();
-            dataTokens.add("YOUR_DATA_TOKEN_1");
-            SignedDataTokens signedToken = SignedDataTokens.builder()
-                    .setCredentials(fileContents)
-                    .setCtx(context)
-                    .setTimeToLive(30) // in seconds
-                    .setDataTokens(dataTokens)
-                    .build();
-            signedTokenValues = signedToken.getSignedDataTokens();
-            System.out.println(signedTokenValues);
-        } catch (SkyflowException e) {
-            e.printStackTrace();
-        }
-    }
-}
+SignedDataTokens signedToken = SignedDataTokens.builder()
+        .setCredentials(new File(filePath))
+        .setCtx(ctx)
+        .setTimeToLive(30)
+        .setDataTokens(dataTokens)
+        .build();
 ```
+
+[Full example](https://github.com/skyflowapi/skyflow-java/blob/main/samples/src/main/java/com/example/serviceaccount/SignedTokenGenerationExample.java)
 
 Response:
 

--- a/samples/src/main/java/com/example/serviceaccount/BearerTokenGenerationWithContextExample.java
+++ b/samples/src/main/java/com/example/serviceaccount/BearerTokenGenerationWithContextExample.java
@@ -4,57 +4,69 @@ import com.skyflow.errors.SkyflowException;
 import com.skyflow.serviceaccount.util.BearerToken;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Example program to generate a Bearer Token using Skyflow's BearerToken utility.
- * The token is generated using two approaches:
- * 1. By providing the credentials.json file path.
- * 2. By providing the contents of credentials.json as a string.
+ * The token is generated using three approaches:
+ * 1. By providing a string context.
+ * 2. By providing a JSON object context (Map) for conditional data access policies.
+ * 3. By providing the credentials as a string with context.
  */
 public class BearerTokenGenerationWithContextExample {
     public static void main(String[] args) {
-        // Variable to store the generated Bearer Token
         String bearerToken = null;
 
-        // Approach 1: Generate Bearer Token by specifying the path to the credentials.json file
+        // Approach 1: Bearer token with string context
+        // Use a simple string identifier when your policy references a single context value.
         try {
-            // Replace <YOUR_CREDENTIALS_FILE_PATH> with the full path to your credentials.json file
             String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
-
-            // Create a BearerToken object using the file path
             BearerToken token = BearerToken.builder()
-                    .setCredentials(new File(filePath)) // Set credentials using a File object
-                    .setCtx("abc") // Set context string (example: "abc")
-                    .build(); // Build the BearerToken object
+                    .setCredentials(new File(filePath))
+                    .setCtx("user_12345")
+                    .build();
 
-            // Retrieve the Bearer Token as a string
             bearerToken = token.getBearerToken();
-
-            // Print the generated Bearer Token to the console
-            System.out.println(bearerToken);
+            System.out.println("Bearer token (string context): " + bearerToken);
         } catch (SkyflowException e) {
-            // Handle exceptions specific to Skyflow operations
             e.printStackTrace();
         }
 
-        // Approach 2: Generate Bearer Token by specifying the contents of credentials.json as a string
+        // Approach 2: Bearer token with JSON object context
+        // Use a structured Map when your policy needs multiple context values.
+        // Each key maps to a Skyflow CEL policy variable under request.context.*
+        // For example, the map below enables policies like:
+        //   request.context.role == "admin" && request.context.department == "finance"
         try {
-            // Replace <YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING> with the actual contents of your credentials.json file
-            String fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>";
+            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
+            Map<String, Object> ctx = new HashMap<>();
+            ctx.put("role", "admin");
+            ctx.put("department", "finance");
+            ctx.put("user_id", "user_12345");
 
-            // Create a BearerToken object using the file contents as a string
             BearerToken token = BearerToken.builder()
-                    .setCredentials(fileContents) // Set credentials using a string representation of the file
-                    .setCtx("abc") // Set context string (example: "abc")
-                    .build(); // Build the BearerToken object
+                    .setCredentials(new File(filePath))
+                    .setCtx(ctx)
+                    .build();
 
-            // Retrieve the Bearer Token as a string
             bearerToken = token.getBearerToken();
-
-            // Print the generated Bearer Token to the console
-            System.out.println(bearerToken);
+            System.out.println("Bearer token (object context): " + bearerToken);
         } catch (SkyflowException e) {
-            // Handle exceptions specific to Skyflow operations
+            e.printStackTrace();
+        }
+
+        // Approach 3: Bearer token with string context from credentials string
+        try {
+            String fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>";
+            BearerToken token = BearerToken.builder()
+                    .setCredentials(fileContents)
+                    .setCtx("user_12345")
+                    .build();
+
+            bearerToken = token.getBearerToken();
+            System.out.println("Bearer token (creds string): " + bearerToken);
+        } catch (SkyflowException e) {
             e.printStackTrace();
         }
     }

--- a/samples/src/main/java/com/example/serviceaccount/SignedTokenGenerationExample.java
+++ b/samples/src/main/java/com/example/serviceaccount/SignedTokenGenerationExample.java
@@ -6,68 +6,83 @@ import com.skyflow.serviceaccount.util.SignedDataTokens;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * This example demonstrates how to generate Signed Data Tokens using two methods:
- * 1. Specifying the path to a credentials JSON file.
- * 2. Providing the credentials JSON as a string.
- * <p>
- * Signed data tokens are used to verify and securely transmit data with a specified context and TTL.
+ * This example demonstrates how to generate Signed Data Tokens using:
+ * 1. String context.
+ * 2. JSON object context (Map) for conditional data access policies.
+ * 3. Credentials string with context.
  */
 public class SignedTokenGenerationExample {
     public static void main(String[] args) {
-        List<SignedDataTokenResponse> signedTokenValues; // List to store signed data token responses
+        List<SignedDataTokenResponse> signedTokenValues;
 
-        // Example 1: Generate Signed Data Token using a credentials file path
+        // Example 1: Signed data tokens with string context
         try {
-            // Step 1: Specify the path to the service account credentials JSON file
-            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>"; // Replace with the actual file path
-
-            // Step 2: Set the context and create the list of data tokens to be signed
-            String context = "abc"; // Replace with your specific context (e.g., session identifier)
+            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
+            String context = "user_12345";
             ArrayList<String> dataTokens = new ArrayList<>();
-            dataTokens.add("YOUR_DATA_TOKEN_1"); // Replace with your actual data token(s)
+            dataTokens.add("YOUR_DATA_TOKEN_1");
 
-            // Step 3: Build the SignedDataTokens object
             SignedDataTokens signedToken = SignedDataTokens.builder()
-                    .setCredentials(new File(filePath)) // Provide the credentials file
-                    .setCtx(context)                   // Set the context for the token
-                    .setTimeToLive(30)                 // Set the TTL (in seconds)
-                    .setDataTokens(dataTokens)         // Set the data tokens to sign
+                    .setCredentials(new File(filePath))
+                    .setCtx(context)
+                    .setTimeToLive(30)
+                    .setDataTokens(dataTokens)
                     .build();
 
-            // Step 4: Retrieve and print the signed data tokens
             signedTokenValues = signedToken.getSignedDataTokens();
-            System.out.println("Signed Tokens (using file path): " + signedTokenValues);
+            System.out.println("Signed Tokens (string context): " + signedTokenValues);
         } catch (SkyflowException e) {
-            System.out.println("Error occurred while generating signed tokens using file path:");
             e.printStackTrace();
         }
 
-        // Example 2: Generate Signed Data Token using credentials JSON as a string
+        // Example 2: Signed data tokens with JSON object context
+        // Each key maps to a Skyflow CEL policy variable under request.context.*
+        // For example: request.context.role == "analyst" && request.context.department == "research"
         try {
-            // Step 1: Provide the contents of the credentials JSON file as a string
-            String fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>"; // Replace with actual JSON content
+            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
+            Map<String, Object> ctx = new HashMap<>();
+            ctx.put("role", "analyst");
+            ctx.put("department", "research");
+            ctx.put("user_id", "user_67890");
 
-            // Step 2: Set the context and create the list of data tokens to be signed
-            String context = "abc"; // Replace with your specific context
             ArrayList<String> dataTokens = new ArrayList<>();
-            dataTokens.add("YOUR_DATA_TOKEN_1"); // Replace with your actual data token(s)
+            dataTokens.add("YOUR_DATA_TOKEN_1");
 
-            // Step 3: Build the SignedDataTokens object
             SignedDataTokens signedToken = SignedDataTokens.builder()
-                    .setCredentials(fileContents)       // Provide the credentials as a string
-                    .setCtx(context)                   // Set the context for the token
-                    .setTimeToLive(30)                 // Set the TTL (in seconds)
-                    .setDataTokens(dataTokens)         // Set the data tokens to sign
+                    .setCredentials(new File(filePath))
+                    .setCtx(ctx)
+                    .setTimeToLive(30)
+                    .setDataTokens(dataTokens)
                     .build();
 
-            // Step 4: Retrieve and print the signed data tokens
             signedTokenValues = signedToken.getSignedDataTokens();
-            System.out.println("Signed Tokens (using credentials string): " + signedTokenValues);
+            System.out.println("Signed Tokens (object context): " + signedTokenValues);
         } catch (SkyflowException e) {
-            System.out.println("Error occurred while generating signed tokens using credentials string:");
+            e.printStackTrace();
+        }
+
+        // Example 3: Signed data tokens from credentials string
+        try {
+            String fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>";
+            String context = "user_12345";
+            ArrayList<String> dataTokens = new ArrayList<>();
+            dataTokens.add("YOUR_DATA_TOKEN_1");
+
+            SignedDataTokens signedToken = SignedDataTokens.builder()
+                    .setCredentials(fileContents)
+                    .setCtx(context)
+                    .setTimeToLive(30)
+                    .setDataTokens(dataTokens)
+                    .build();
+
+            signedTokenValues = signedToken.getSignedDataTokens();
+            System.out.println("Signed Tokens (creds string): " + signedTokenValues);
+        } catch (SkyflowException e) {
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/skyflow/config/Credentials.java
+++ b/src/main/java/com/skyflow/config/Credentials.java
@@ -1,11 +1,12 @@
 package com.skyflow.config;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class Credentials {
     private String path;
     private ArrayList<String> roles;
-    private String context;
+    private Object context;
     private String credentialsString;
     private String token;
     private String apiKey;
@@ -32,11 +33,15 @@ public class Credentials {
         this.roles = roles;
     }
 
-    public String getContext() {
+    public Object getContext() {
         return context;
     }
 
     public void setContext(String context) {
+        this.context = context;
+    }
+
+    public void setContext(Map<String, Object> context) {
         this.context = context;
     }
 

--- a/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -34,6 +34,8 @@ public enum ErrorMessage {
     EmptyRoles("%s0 Initialization failed. Invalid roles. Specify at least one role."),
     EmptyRoleInRoles("%s0 Initialization failed. Invalid role. Specify a valid role."),
     EmptyContext("%s0 Initialization failed. Invalid context. Specify a valid context."),
+    InvalidContextType("%s0 Initialization failed. Invalid context type. Specify context as a String or Map<String, Object>."),
+    InvalidContextMapKey("%s0 Initialization failed. Invalid key '%s1' in context map. Keys must contain only alphanumeric characters and underscores."),
 
     // Bearer token generation
     FileNotFound("%s0 Initialization failed. Credential file not found at %s1. Verify the file path."),

--- a/src/main/java/com/skyflow/logs/ErrorLogs.java
+++ b/src/main/java/com/skyflow/logs/ErrorLogs.java
@@ -25,6 +25,8 @@ public enum ErrorLogs {
     EMPTY_ROLES("Invalid credentials. Roles can not be empty."),
     EMPTY_OR_NULL_ROLE_IN_ROLES("Invalid credentials. Role can not be null or empty in roles at index %s1."),
     EMPTY_OR_NULL_CONTEXT("Invalid credentials. Context can not be empty."),
+    INVALID_CONTEXT_TYPE("Invalid credentials. Context must be a String or Map<String, Object>."),
+    INVALID_CONTEXT_MAP_KEY("Invalid credentials. Context map key '%s1' contains invalid characters."),
 
     // Bearer token generation
     INVALID_BEARER_TOKEN("Bearer token is invalid or expired."),

--- a/src/main/java/com/skyflow/serviceaccount/util/BearerToken.java
+++ b/src/main/java/com/skyflow/serviceaccount/util/BearerToken.java
@@ -24,6 +24,7 @@ import java.net.MalformedURLException;
 import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 public class BearerToken {
@@ -31,7 +32,7 @@ public class BearerToken {
     private static final ApiClientBuilder API_CLIENT_BUILDER = new ApiClientBuilder();
     private final File credentialsFile;
     private final String credentialsString;
-    private final String ctx;
+    private final Object ctx;
     private final ArrayList<String> roles;
     private final String credentialsType;
 
@@ -48,7 +49,7 @@ public class BearerToken {
     }
 
     private static V1GetAuthTokenResponse generateBearerTokenFromCredentials(
-            File credentialsFile, String context, ArrayList<String> roles
+            File credentialsFile, Object context, ArrayList<String> roles
     ) throws SkyflowException {
         LogUtil.printInfoLog(InfoLogs.GENERATE_BEARER_TOKEN_FROM_CREDENTIALS_TRIGGERED.getLog());
         try {
@@ -71,7 +72,7 @@ public class BearerToken {
     }
 
     private static V1GetAuthTokenResponse generateBearerTokenFromCredentialString(
-            String credentials, String context, ArrayList<String> roles
+            String credentials, Object context, ArrayList<String> roles
     ) throws SkyflowException {
         LogUtil.printInfoLog(InfoLogs.GENERATE_BEARER_TOKEN_FROM_CREDENTIALS_STRING_TRIGGERED.getLog());
         try {
@@ -89,7 +90,7 @@ public class BearerToken {
     }
 
     private static V1GetAuthTokenResponse getBearerTokenFromCredentials(
-            JsonObject credentials, String context, ArrayList<String> roles
+            JsonObject credentials, Object context, ArrayList<String> roles
     ) throws SkyflowException {
         try {
             JsonElement privateKey = credentials.get("privateKey");
@@ -144,19 +145,22 @@ public class BearerToken {
     }
 
     private static String getSignedToken(
-            String clientID, String keyID, String tokenURI, PrivateKey pvtKey, String context
+            String clientID, String keyID, String tokenURI, PrivateKey pvtKey, Object context
     ) {
         final Date createdDate = new Date();
         final Date expirationDate = new Date(createdDate.getTime() + (3600 * 1000));
-        return Jwts.builder()
+        io.jsonwebtoken.JwtBuilder builder = Jwts.builder()
                 .claim("iss", clientID)
                 .claim("key", keyID)
                 .claim("aud", tokenURI)
                 .claim("sub", clientID)
-                .claim("ctx", context)
-                .expiration(expirationDate)
-                .signWith(pvtKey, Jwts.SIG.RS256)
-                .compact();
+                .expiration(expirationDate);
+
+        if (context != null) {
+            builder.claim("ctx", context);
+        }
+
+        return builder.signWith(pvtKey, Jwts.SIG.RS256).compact();
     }
 
     private static String getScopeUsingRoles(ArrayList<String> roles) {
@@ -188,7 +192,7 @@ public class BearerToken {
     public static class BearerTokenBuilder {
         private File credentialsFile;
         private String credentialsString;
-        private String ctx;
+        private Object ctx;
         private ArrayList<String> roles;
         private String credentialsType;
 
@@ -212,6 +216,11 @@ public class BearerToken {
         }
 
         public BearerTokenBuilder setCtx(String ctx) {
+            this.ctx = ctx;
+            return this;
+        }
+
+        public BearerTokenBuilder setCtx(Map<String, Object> ctx) {
             this.ctx = ctx;
             return this;
         }

--- a/src/main/java/com/skyflow/serviceaccount/util/SignedDataTokens.java
+++ b/src/main/java/com/skyflow/serviceaccount/util/SignedDataTokens.java
@@ -20,13 +20,14 @@ import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class SignedDataTokens {
     private final File credentialsFile;
     private final String credentialsString;
     private final String credentialsType;
-    private final String ctx;
+    private final Object ctx;
     private final ArrayList<String> dataTokens;
     private final Integer timeToLive;
 
@@ -44,7 +45,7 @@ public class SignedDataTokens {
     }
 
     private static List<SignedDataTokenResponse> generateSignedTokenFromCredentialsFile(
-            File credentialsFile, ArrayList<String> dataTokens, Integer timeToLive, String context
+            File credentialsFile, ArrayList<String> dataTokens, Integer timeToLive, Object context
     ) throws SkyflowException {
         LogUtil.printInfoLog(InfoLogs.GENERATE_SIGNED_TOKENS_FROM_CREDENTIALS_FILE_TRIGGERED.getLog());
         List<SignedDataTokenResponse> responseToken;
@@ -69,7 +70,7 @@ public class SignedDataTokens {
     }
 
     private static List<SignedDataTokenResponse> generateSignedTokensFromCredentialsString(
-            String credentials, ArrayList<String> dataTokens, Integer timeToLive, String context
+            String credentials, ArrayList<String> dataTokens, Integer timeToLive, Object context
     ) throws SkyflowException {
         LogUtil.printInfoLog(InfoLogs.GENERATE_SIGNED_TOKENS_FROM_CREDENTIALS_STRING_TRIGGERED.getLog());
         List<SignedDataTokenResponse> responseToken;
@@ -89,7 +90,7 @@ public class SignedDataTokens {
     }
 
     private static List<SignedDataTokenResponse> generateSignedTokensFromCredentials(
-            JsonObject credentials, ArrayList<String> dataTokens, Integer timeToLive, String context
+            JsonObject credentials, ArrayList<String> dataTokens, Integer timeToLive, Object context
     ) throws SkyflowException {
         List<SignedDataTokenResponse> signedDataTokens = null;
         try {
@@ -122,7 +123,7 @@ public class SignedDataTokens {
 
     private static List<SignedDataTokenResponse> getSignedToken(
             String clientID, String keyID, PrivateKey pvtKey,
-            ArrayList<String> dataTokens, Integer timeToLive, String context
+            ArrayList<String> dataTokens, Integer timeToLive, Object context
     ) {
         final Date createdDate = new Date();
         final Date expirationDate;
@@ -135,16 +136,19 @@ public class SignedDataTokens {
 
         List<SignedDataTokenResponse> list = new ArrayList<>();
         for (String dataToken : dataTokens) {
-            String eachSignedDataToken = Jwts.builder()
+            io.jsonwebtoken.JwtBuilder builder = Jwts.builder()
                     .claim("iss", "sdk")
                     .claim("iat", (createdDate.getTime() / 1000))
                     .claim("key", keyID)
                     .claim("sub", clientID)
-                    .claim("ctx", context)
                     .claim("tok", dataToken)
-                    .expiration(expirationDate)
-                    .signWith(pvtKey, Jwts.SIG.RS256)
-                    .compact();
+                    .expiration(expirationDate);
+
+            if (context != null) {
+                builder.claim("ctx", context);
+            }
+
+            String eachSignedDataToken = builder.signWith(pvtKey, Jwts.SIG.RS256).compact();
             SignedDataTokenResponse responseObject = new SignedDataTokenResponse(dataToken, eachSignedDataToken);
             list.add(responseObject);
         }
@@ -168,7 +172,7 @@ public class SignedDataTokens {
         private Integer timeToLive;
         private File credentialsFile;
         private String credentialsString;
-        private String ctx;
+        private Object ctx;
         private String credentialsType;
 
         private SignedDataTokensBuilder() {
@@ -191,6 +195,11 @@ public class SignedDataTokens {
         }
 
         public SignedDataTokensBuilder setCtx(String ctx) {
+            this.ctx = ctx;
+            return this;
+        }
+
+        public SignedDataTokensBuilder setCtx(Map<String, Object> ctx) {
             this.ctx = ctx;
             return this;
         }

--- a/src/main/java/com/skyflow/utils/Utils.java
+++ b/src/main/java/com/skyflow/utils/Utils.java
@@ -47,21 +47,30 @@ public final class Utils {
         return sb.toString();
     }
 
+    @SuppressWarnings("unchecked")
     public static String generateBearerToken(Credentials credentials) throws SkyflowException {
         if (credentials.getPath() != null) {
-            return BearerToken.builder()
+            BearerToken.BearerTokenBuilder builder = BearerToken.builder()
                     .setCredentials(new File(credentials.getPath()))
-                    .setRoles(credentials.getRoles())
-                    .setCtx(credentials.getContext())
-                    .build()
-                    .getBearerToken();
+                    .setRoles(credentials.getRoles());
+            Object ctx = credentials.getContext();
+            if (ctx instanceof String) {
+                builder.setCtx((String) ctx);
+            } else if (ctx instanceof Map) {
+                builder.setCtx((Map<String, Object>) ctx);
+            }
+            return builder.build().getBearerToken();
         } else if (credentials.getCredentialsString() != null) {
-            return BearerToken.builder()
+            BearerToken.BearerTokenBuilder builder = BearerToken.builder()
                     .setCredentials(credentials.getCredentialsString())
-                    .setRoles(credentials.getRoles())
-                    .setCtx(credentials.getContext())
-                    .build()
-                    .getBearerToken();
+                    .setRoles(credentials.getRoles());
+            Object ctx = credentials.getContext();
+            if (ctx instanceof String) {
+                builder.setCtx((String) ctx);
+            } else if (ctx instanceof Map) {
+                builder.setCtx((Map<String, Object>) ctx);
+            }
+            return builder.build().getBearerToken();
         } else {
             return credentials.getToken();
         }

--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -162,7 +162,7 @@ public class Validations {
         String credentialsString = credentials.getCredentialsString();
         String token = credentials.getToken();
         String apiKey = credentials.getApiKey();
-        String context = credentials.getContext();
+        Object context = credentials.getContext();
         ArrayList<String> roles = credentials.getRoles();
 
         if (path != null) nonNullMembers++;
@@ -217,9 +217,33 @@ public class Validations {
                 }
             }
         }
-        if (context != null && context.trim().isEmpty()) {
-            LogUtil.printErrorLog(ErrorLogs.EMPTY_OR_NULL_CONTEXT.getLog());
-            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyContext.getMessage());
+        if (context != null) {
+            if (context instanceof String) {
+                String ctxStr = (String) context;
+                if (ctxStr.trim().isEmpty()) {
+                    LogUtil.printErrorLog(ErrorLogs.EMPTY_OR_NULL_CONTEXT.getLog());
+                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyContext.getMessage());
+                }
+            } else if (context instanceof Map) {
+                Map<?, ?> ctxMap = (Map<?, ?>) context;
+                if (ctxMap.isEmpty()) {
+                    LogUtil.printErrorLog(ErrorLogs.EMPTY_OR_NULL_CONTEXT.getLog());
+                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyContext.getMessage());
+                }
+                Pattern ctxKeyPattern = Pattern.compile("^[a-zA-Z0-9_]+$");
+                for (Object key : ctxMap.keySet()) {
+                    if (key == null || !ctxKeyPattern.matcher(key.toString()).matches()) {
+                        String keyStr = key == null ? "null" : key.toString();
+                        LogUtil.printErrorLog(Utils.parameterizedString(
+                                ErrorLogs.INVALID_CONTEXT_MAP_KEY.getLog(), keyStr));
+                        throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(),
+                                Utils.parameterizedString(ErrorMessage.InvalidContextMapKey.getMessage(), keyStr));
+                    }
+                }
+            } else {
+                LogUtil.printErrorLog(ErrorLogs.INVALID_CONTEXT_TYPE.getLog());
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidContextType.getMessage());
+            }
         }
     }
 

--- a/src/test/java/com/skyflow/config/CredentialsTests.java
+++ b/src/test/java/com/skyflow/config/CredentialsTests.java
@@ -10,6 +10,10 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
+
+import com.skyflow.utils.Utils;
 
 public class CredentialsTests {
     private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
@@ -263,6 +267,88 @@ public class CredentialsTests {
         } catch (SkyflowException e) {
             Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
             Assert.assertEquals(ErrorMessage.EmptyContext.getMessage(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testValidMapContextInCredentials() {
+        try {
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            Map<String, Object> ctxMap = new HashMap<>();
+            ctxMap.put("role", "admin");
+            ctxMap.put("department", "finance");
+            ctxMap.put("user_id", "user_12345");
+            credentials.setContext(ctxMap);
+            Validations.validateCredentials(credentials);
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testEmptyMapContextInCredentials() {
+        try {
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            Map<String, Object> ctxMap = new HashMap<>();
+            credentials.setContext(ctxMap);
+            Validations.validateCredentials(credentials);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(ErrorMessage.EmptyContext.getMessage(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testInvalidMapKeyInContextCredentials() {
+        try {
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            Map<String, Object> ctxMap = new HashMap<>();
+            ctxMap.put("valid_key", "value");
+            ctxMap.put("invalid-key", "value");
+            credentials.setContext(ctxMap);
+            Validations.validateCredentials(credentials);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertTrue(e.getMessage().contains("invalid-key"));
+        }
+    }
+
+    @Test
+    public void testMapContextWithNestedObjects() {
+        try {
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            Map<String, Object> nested = new HashMap<>();
+            nested.put("level", 2);
+            Map<String, Object> ctxMap = new HashMap<>();
+            ctxMap.put("role", "admin");
+            ctxMap.put("metadata", nested);
+            credentials.setContext(ctxMap);
+            Validations.validateCredentials(credentials);
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testMapContextWithMixedValueTypes() {
+        try {
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            Map<String, Object> ctxMap = new HashMap<>();
+            ctxMap.put("role", "admin");
+            ctxMap.put("level", 3);
+            ctxMap.put("active", true);
+            ctxMap.put("timestamp", "2025-12-25T10:30:00Z");
+            credentials.setContext(ctxMap);
+            Validations.validateCredentials(credentials);
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
         }
     }
 

--- a/src/test/java/com/skyflow/serviceaccount/util/BearerTokenTests.java
+++ b/src/test/java/com/skyflow/serviceaccount/util/BearerTokenTests.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class BearerTokenTests {
     private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
@@ -51,7 +53,32 @@ public class BearerTokenTests {
         } catch (Exception e) {
             Assert.fail(INVALID_EXCEPTION_THROWN);
         }
+    }
 
+    @Test
+    public void testBearerTokenBuilderWithMapContext() {
+        try {
+            Map<String, Object> ctxMap = new HashMap<>();
+            ctxMap.put("role", "admin");
+            ctxMap.put("department", "finance");
+            ctxMap.put("user_id", "user_12345");
+            File file = new File(credentialsFilePath);
+            BearerToken.builder().setCredentials(file).setCtx(ctxMap).build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testBearerTokenBuilderWithMapContextFromString() {
+        try {
+            Map<String, Object> ctxMap = new HashMap<>();
+            ctxMap.put("role", "analyst");
+            ctxMap.put("level", 3);
+            BearerToken.builder().setCredentials(credentialsString).setCtx(ctxMap).build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
     }
 
     @Test

--- a/src/test/java/com/skyflow/serviceaccount/util/SignedDataTokensTests.java
+++ b/src/test/java/com/skyflow/serviceaccount/util/SignedDataTokensTests.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class SignedDataTokensTests {
     private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
@@ -57,7 +59,21 @@ public class SignedDataTokensTests {
         } catch (Exception e) {
             Assert.fail(INVALID_EXCEPTION_THROWN);
         }
+    }
 
+    @Test
+    public void testSignedDataTokensBuilderWithMapContext() {
+        try {
+            Map<String, Object> ctxMap = new HashMap<>();
+            ctxMap.put("role", "admin");
+            ctxMap.put("department", "finance");
+            File file = new File(credentialsFilePath);
+            SignedDataTokens.builder()
+                    .setCredentials(file).setCtx(ctxMap).setDataTokens(dataTokens).setTimeToLive(ttl)
+                    .build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary

- Extends bearer token and signed data token generation to accept `Map<String, Object>` for the `ctx` field, in addition to the existing `String` type
- Enables structured context for conditional data access policies where ctx object keys map to Skyflow CEL policy variables (`request.context.role`, `request.context.department`, etc.)
- Adds key validation: map keys must match `[a-zA-Z0-9_]+` for CEL compatibility
- JJWT's `.claim(String, Object)` natively serializes Map as a JSON object in the JWT payload — no custom serialization needed
- Updated `Credentials.setContext()`, `BearerTokenBuilder.setCtx()`, `SignedDataTokensBuilder.setCtx()` with overloaded methods
- New error messages: `InvalidContextType`, `InvalidContextMapKey`
- 51 tests passing (including new Map-based context tests)
- Updated README and samples with both string and object ctx patterns

## Test plan

- [x] `mvn test` — 51 tests pass (BearerTokenTests, SignedDataTokensTests, CredentialsTests)
- [ ] Integration test with Skyflow backend using Map ctx in bearer token
- [ ] Verify JWT payload contains ctx as JSON object (not stringified)

Resolves: SK-2679, DOCU-1438

🤖 Generated with [Claude Code](https://claude.com/claude-code)