### PR TITLE
SK-2679: Add JSON object context support for Conditional Data Access

### DIFF
--- a/README.md
+++ b/README.md
@@ -2771,9 +2771,13 @@ public class BearerTokenGenerationExample {
 
 ## Generate bearer tokens with context
 
-**Context-aware authorization** embeds context values into a bearer token during its generation and so you can reference those values in your policies. This enables more flexible access controls, such as helping you track end-user identity when making API calls using service accounts, and facilitates using signed data tokens during detokenization. .
+**Context-aware authorization** embeds context values into a bearer token during its generation and so you can reference those values in your policies. This enables more flexible access controls, such as helping you track end-user identity when making API calls using service accounts, and facilitates using signed data tokens during detokenization.
 
 A service account with the `context_id` identifier generates bearer tokens containing context information, represented as a JWT claim in a Skyflow-generated bearer token. Tokens generated from such service accounts include a `context_identifier` claim, are valid for 60 minutes, and can be used to make API calls to the Data and Management APIs, depending on the service account's permissions.
+
+The context can be provided as a simple string or as a `Map<String, Object>` for structured context. Use a `Map` when your policies use Conditional Data Access with CEL expressions that reference nested context fields (e.g., `request.context.role == 'admin'`).
+
+### String context
 
 [Example](https://github.com/skyflowapi/skyflow-java/blob/main/samples/src/main/java/com/example/serviceaccount/BearerTokenGenerationWithContextExample.java):
 
@@ -2783,60 +2787,44 @@ import com.skyflow.serviceaccount.util.BearerToken;
 
 import java.io.File;
 
-/**
- * Example program to generate a Bearer Token using Skyflow's BearerToken utility.
- * The token is generated using two approaches:
- * 1. By providing the credentials.json file path.
- * 2. By providing the contents of credentials.json as a string.
- */
-public class BearerTokenGenerationWithContextExample {
-    public static void main(String[] args) {
-        // Variable to store the generated Bearer Token
-        String bearerToken = null;
+// Generate Bearer Token with a simple string context
+String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
 
-        // Approach 1: Generate Bearer Token by specifying the path to the credentials.json file
-        try {
-            // Replace <YOUR_CREDENTIALS_FILE_PATH> with the full path to your credentials.json file
-            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
+BearerToken token = BearerToken.builder()
+        .setCredentials(new File(filePath))
+        .setCtx("abc") // Simple string context
+        .build();
 
-            // Create a BearerToken object using the file path
-            BearerToken token = BearerToken.builder()
-                    .setCredentials(new File(filePath)) // Set credentials using a File object
-                    .setCtx("abc") // Set context string (example: "abc")
-                    .build(); // Build the BearerToken object
+String bearerToken = token.getBearerToken();
+```
 
-            // Retrieve the Bearer Token as a string
-            bearerToken = token.getBearerToken();
+### JSON object context (Conditional Data Access)
 
-            // Print the generated Bearer Token to the console
-            System.out.println(bearerToken);
-        } catch (SkyflowException e) {
-            // Handle exceptions specific to Skyflow operations
-            e.printStackTrace();
-        }
+Skyflow's [Conditional Data Access](https://docs.skyflow.com/docs/governance/roles/conditional-data-access/overview) feature enables dynamic, context-aware access control by allowing roles to activate only when specific conditions are met at runtime. Conditions are defined using Common Expression Language (CEL) expressions that evaluate against `request.context`, `request.time`, and `request.originIP`.
 
-        // Approach 2: Generate Bearer Token by specifying the contents of credentials.json as a string
-        try {
-            // Replace <YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING> with the actual contents of your credentials.json file
-            String fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>";
+To satisfy context-based conditions, pass a `Map<String, Object>` to `setCtx()`. The map is embedded as a nested JSON object in the JWT `ctx` claim, allowing CEL expressions to reference individual fields.
 
-            // Create a BearerToken object using the file contents as a string
-            BearerToken token = BearerToken.builder()
-                    .setCredentials(fileContents) // Set credentials using a string representation of the file
-                    .setCtx("abc") // Set context string (example: "abc")
-                    .build(); // Build the BearerToken object
+```java
+import com.skyflow.errors.SkyflowException;
+import com.skyflow.serviceaccount.util.BearerToken;
 
-            // Retrieve the Bearer Token as a string
-            bearerToken = token.getBearerToken();
+import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
-            // Print the generated Bearer Token to the console
-            System.out.println(bearerToken);
-        } catch (SkyflowException e) {
-            // Handle exceptions specific to Skyflow operations
-            e.printStackTrace();
-        }
-    }
-}
+// Create a context map matching your Conditional Data Access policy
+// For example, if your policy condition is:
+//   request.context.role == 'admin' && request.context.project_id == 'proj_123'
+Map<String, Object> context = new HashMap<>();
+context.put("role", "admin");
+context.put("project_id", "proj_123");
+
+BearerToken token = BearerToken.builder()
+        .setCredentials(new File("<YOUR_CREDENTIALS_FILE_PATH>"))
+        .setCtx(context) // JSON object context for Conditional Data Access
+        .build();
+
+String bearerToken = token.getBearerToken();
 ```
 
 ## Generate scoped bearer tokens
@@ -2903,6 +2891,8 @@ with the private key of the service account credentials, which adds an additiona
 be detokenized by passing the signed data token and a bearer token generated from service account credentials. The
 service account must have appropriate permissions and context to detokenize the signed data tokens.
 
+Like bearer tokens, the context can be provided as a simple string or as a `Map<String, Object>` for Conditional Data Access.
+
 [Example](https://github.com/skyflowapi/skyflow-java/blob/main/samples/src/main/java/com/example/serviceaccount/SignedTokenGenerationExample.java):
 
 ```java
@@ -2912,12 +2902,15 @@ import com.skyflow.serviceaccount.util.SignedDataTokens;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 public class SignedTokenGenerationExample {
     public static void main(String[] args) {
         List<SignedDataTokenResponse> signedTokenValues;
-        // Generate Signed data token with context by specifying credentials.json file path
+
+        // Generate Signed data token with string context
         try {
             String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
             String context = "abc";
@@ -2935,15 +2928,17 @@ public class SignedTokenGenerationExample {
             e.printStackTrace();
         }
 
-        // Generate Signed data token with context by specifying credentials.json as string
+        // Generate Signed data token with JSON object context for Conditional Data Access
         try {
-            String fileContents = "<YOUR_CREDENTIALS_FILE_CONTENTS_AS_STRING>";
-            String context = "abc";
+            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
+            Map<String, Object> context = new HashMap<>();
+            context.put("role", "admin");
+            context.put("project_id", "proj_123");
             ArrayList<String> dataTokens = new ArrayList<>();
             dataTokens.add("YOUR_DATA_TOKEN_1");
             SignedDataTokens signedToken = SignedDataTokens.builder()
-                    .setCredentials(fileContents)
-                    .setCtx(context)
+                    .setCredentials(new File(filePath))
+                    .setCtx(context) // JSON object context
                     .setTimeToLive(30) // in seconds
                     .setDataTokens(dataTokens)
                     .build();

--- a/samples/src/main/java/com/example/serviceaccount/BearerTokenGenerationWithContextExample.java
+++ b/samples/src/main/java/com/example/serviceaccount/BearerTokenGenerationWithContextExample.java
@@ -4,12 +4,15 @@ import com.skyflow.errors.SkyflowException;
 import com.skyflow.serviceaccount.util.BearerToken;
 
 import java.io.File;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * Example program to generate a Bearer Token using Skyflow's BearerToken utility.
- * The token is generated using two approaches:
- * 1. By providing the credentials.json file path.
- * 2. By providing the contents of credentials.json as a string.
+ * The token is generated using three approaches:
+ * 1. By providing the credentials.json file path with a string context.
+ * 2. By providing the contents of credentials.json as a string with a string context.
+ * 3. By providing a JSON object context for Conditional Data Access.
  */
 public class BearerTokenGenerationWithContextExample {
     public static void main(String[] args) {
@@ -47,6 +50,34 @@ public class BearerTokenGenerationWithContextExample {
                     .setCredentials(fileContents) // Set credentials using a string representation of the file
                     .setCtx("abc") // Set context string (example: "abc")
                     .build(); // Build the BearerToken object
+
+            // Retrieve the Bearer Token as a string
+            bearerToken = token.getBearerToken();
+
+            // Print the generated Bearer Token to the console
+            System.out.println(bearerToken);
+        } catch (SkyflowException e) {
+            // Handle exceptions specific to Skyflow operations
+            e.printStackTrace();
+        }
+
+        // Approach 3: Generate Bearer Token with a JSON object context for Conditional Data Access
+        // Use this approach when your Skyflow policy uses CEL expressions that reference nested
+        // context fields, such as: request.context.role == 'admin'
+        try {
+            // Replace <YOUR_CREDENTIALS_FILE_PATH> with the full path to your credentials.json file
+            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>";
+
+            // Create a context map with key-value pairs matching your Conditional Data Access policy
+            Map<String, Object> context = new HashMap<>();
+            context.put("role", "admin");              // Evaluated as request.context.role
+            context.put("project_id", "proj_123");     // Evaluated as request.context.project_id
+
+            // Create a BearerToken object with the JSON object context
+            BearerToken token = BearerToken.builder()
+                    .setCredentials(new File(filePath)) // Set credentials using a File object
+                    .setCtx(context)                    // Set context as a JSON object
+                    .build();                           // Build the BearerToken object
 
             // Retrieve the Bearer Token as a string
             bearerToken = token.getBearerToken();

--- a/samples/src/main/java/com/example/serviceaccount/SignedTokenGenerationExample.java
+++ b/samples/src/main/java/com/example/serviceaccount/SignedTokenGenerationExample.java
@@ -6,12 +6,15 @@ import com.skyflow.serviceaccount.util.SignedDataTokens;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
- * This example demonstrates how to generate Signed Data Tokens using two methods:
- * 1. Specifying the path to a credentials JSON file.
- * 2. Providing the credentials JSON as a string.
+ * This example demonstrates how to generate Signed Data Tokens using three methods:
+ * 1. Specifying the path to a credentials JSON file with a string context.
+ * 2. Providing the credentials JSON as a string with a string context.
+ * 3. Using a JSON object context for Conditional Data Access.
  * <p>
  * Signed data tokens are used to verify and securely transmit data with a specified context and TTL.
  */
@@ -68,6 +71,37 @@ public class SignedTokenGenerationExample {
             System.out.println("Signed Tokens (using credentials string): " + signedTokenValues);
         } catch (SkyflowException e) {
             System.out.println("Error occurred while generating signed tokens using credentials string:");
+            e.printStackTrace();
+        }
+
+        // Example 3: Generate Signed Data Token with a JSON object context for Conditional Data Access
+        // Use this approach when your Skyflow policy uses CEL expressions that reference nested
+        // context fields, such as: request.context.role == 'admin'
+        try {
+            // Step 1: Specify the path to the service account credentials JSON file
+            String filePath = "<YOUR_CREDENTIALS_FILE_PATH>"; // Replace with the actual file path
+
+            // Step 2: Create a context map with key-value pairs matching your Conditional Data Access policy
+            Map<String, Object> context = new HashMap<>();
+            context.put("role", "admin");              // Evaluated as request.context.role
+            context.put("project_id", "proj_123");     // Evaluated as request.context.project_id
+
+            ArrayList<String> dataTokens = new ArrayList<>();
+            dataTokens.add("YOUR_DATA_TOKEN_1"); // Replace with your actual data token(s)
+
+            // Step 3: Build the SignedDataTokens object with the JSON object context
+            SignedDataTokens signedToken = SignedDataTokens.builder()
+                    .setCredentials(new File(filePath)) // Provide the credentials file
+                    .setCtx(context)                    // Set context as a JSON object
+                    .setTimeToLive(30)                  // Set the TTL (in seconds)
+                    .setDataTokens(dataTokens)          // Set the data tokens to sign
+                    .build();
+
+            // Step 4: Retrieve and print the signed data tokens
+            signedTokenValues = signedToken.getSignedDataTokens();
+            System.out.println("Signed Tokens (using JSON object context): " + signedTokenValues);
+        } catch (SkyflowException e) {
+            System.out.println("Error occurred while generating signed tokens with JSON object context:");
             e.printStackTrace();
         }
     }

--- a/src/main/java/com/skyflow/config/Credentials.java
+++ b/src/main/java/com/skyflow/config/Credentials.java
@@ -1,11 +1,12 @@
 package com.skyflow.config;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class Credentials {
     private String path;
     private ArrayList<String> roles;
-    private String context;
+    private Object context;
     private String credentialsString;
     private String token;
     private String apiKey;
@@ -33,10 +34,18 @@ public class Credentials {
     }
 
     public String getContext() {
+        return context instanceof String ? (String) context : null;
+    }
+
+    public Object getContextAsObject() {
         return context;
     }
 
     public void setContext(String context) {
+        this.context = context;
+    }
+
+    public void setContext(Map<String, Object> context) {
         this.context = context;
     }
 

--- a/src/main/java/com/skyflow/config/Credentials.java
+++ b/src/main/java/com/skyflow/config/Credentials.java
@@ -41,6 +41,11 @@ public class Credentials {
         return context;
     }
 
+    @SuppressWarnings("unchecked")
+    public Map<String, Object> getContextAsMap() {
+        return context instanceof Map ? (Map<String, Object>) context : null;
+    }
+
     public void setContext(String context) {
         this.context = context;
     }

--- a/src/main/java/com/skyflow/errors/ErrorMessage.java
+++ b/src/main/java/com/skyflow/errors/ErrorMessage.java
@@ -34,6 +34,8 @@ public enum ErrorMessage {
     EmptyRoles("%s0 Initialization failed. Invalid roles. Specify at least one role."),
     EmptyRoleInRoles("%s0 Initialization failed. Invalid role. Specify a valid role."),
     EmptyContext("%s0 Initialization failed. Invalid context. Specify a valid context."),
+    InvalidCtxType("%s0 Initialization failed. Invalid context type. Context must be a string or a map."),
+    InvalidCtxMapKey("%s0 Initialization failed. Invalid context map key '%s1'. Context map keys must contain only alphanumeric characters and underscores."),
 
     // Bearer token generation
     FileNotFound("%s0 Initialization failed. Credential file not found at %s1. Verify the file path."),

--- a/src/main/java/com/skyflow/logs/ErrorLogs.java
+++ b/src/main/java/com/skyflow/logs/ErrorLogs.java
@@ -25,6 +25,8 @@ public enum ErrorLogs {
     EMPTY_ROLES("Invalid credentials. Roles can not be empty."),
     EMPTY_OR_NULL_ROLE_IN_ROLES("Invalid credentials. Role can not be null or empty in roles at index %s1."),
     EMPTY_OR_NULL_CONTEXT("Invalid credentials. Context can not be empty."),
+    INVALID_CTX_TYPE("Invalid credentials. Context must be a string or a map."),
+    INVALID_CTX_MAP_KEY("Invalid credentials. Context map key '%s1' is invalid. Keys must match ^[a-zA-Z0-9_]+$."),
 
     // Bearer token generation
     INVALID_BEARER_TOKEN("Bearer token is invalid or expired."),

--- a/src/main/java/com/skyflow/serviceaccount/util/BearerToken.java
+++ b/src/main/java/com/skyflow/serviceaccount/util/BearerToken.java
@@ -17,6 +17,8 @@ import com.skyflow.utils.Utils;
 import com.skyflow.utils.logger.LogUtil;
 import io.jsonwebtoken.Jwts;
 
+import com.skyflow.utils.validations.Validations;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -24,6 +26,7 @@ import java.net.MalformedURLException;
 import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Date;
+import java.util.Map;
 import java.util.Objects;
 
 public class BearerToken {
@@ -31,7 +34,7 @@ public class BearerToken {
     private static final ApiClientBuilder API_CLIENT_BUILDER = new ApiClientBuilder();
     private final File credentialsFile;
     private final String credentialsString;
-    private final String ctx;
+    private final Object ctx;
     private final ArrayList<String> roles;
     private final String credentialsType;
 
@@ -48,7 +51,7 @@ public class BearerToken {
     }
 
     private static V1GetAuthTokenResponse generateBearerTokenFromCredentials(
-            File credentialsFile, String context, ArrayList<String> roles
+            File credentialsFile, Object context, ArrayList<String> roles
     ) throws SkyflowException {
         LogUtil.printInfoLog(InfoLogs.GENERATE_BEARER_TOKEN_FROM_CREDENTIALS_TRIGGERED.getLog());
         try {
@@ -71,7 +74,7 @@ public class BearerToken {
     }
 
     private static V1GetAuthTokenResponse generateBearerTokenFromCredentialString(
-            String credentials, String context, ArrayList<String> roles
+            String credentials, Object context, ArrayList<String> roles
     ) throws SkyflowException {
         LogUtil.printInfoLog(InfoLogs.GENERATE_BEARER_TOKEN_FROM_CREDENTIALS_STRING_TRIGGERED.getLog());
         try {
@@ -89,7 +92,7 @@ public class BearerToken {
     }
 
     private static V1GetAuthTokenResponse getBearerTokenFromCredentials(
-            JsonObject credentials, String context, ArrayList<String> roles
+            JsonObject credentials, Object context, ArrayList<String> roles
     ) throws SkyflowException {
         try {
             JsonElement privateKey = credentials.get("privateKey");
@@ -144,8 +147,19 @@ public class BearerToken {
     }
 
     private static String getSignedToken(
-            String clientID, String keyID, String tokenURI, PrivateKey pvtKey, String context
-    ) {
+            String clientID, String keyID, String tokenURI, PrivateKey pvtKey, Object context
+    ) throws SkyflowException {
+        // Validate and normalize context
+        Object validatedContext = context;
+        if (context instanceof Map) {
+            Map<?, ?> ctxMap = (Map<?, ?>) context;
+            if (ctxMap.isEmpty()) {
+                validatedContext = null;
+            } else {
+                Validations.validateCtxMapKeys(ctxMap);
+            }
+        }
+
         final Date createdDate = new Date();
         final Date expirationDate = new Date(createdDate.getTime() + (3600 * 1000));
         return Jwts.builder()
@@ -153,7 +167,7 @@ public class BearerToken {
                 .claim("key", keyID)
                 .claim("aud", tokenURI)
                 .claim("sub", clientID)
-                .claim("ctx", context)
+                .claim("ctx", validatedContext)
                 .expiration(expirationDate)
                 .signWith(pvtKey, Jwts.SIG.RS256)
                 .compact();
@@ -188,7 +202,7 @@ public class BearerToken {
     public static class BearerTokenBuilder {
         private File credentialsFile;
         private String credentialsString;
-        private String ctx;
+        private Object ctx;
         private ArrayList<String> roles;
         private String credentialsType;
 
@@ -212,6 +226,14 @@ public class BearerToken {
         }
 
         public BearerTokenBuilder setCtx(String ctx) {
+            this.ctx = ctx;
+            return this;
+        }
+
+        public BearerTokenBuilder setCtx(Map<String, Object> ctx) throws SkyflowException {
+            if (ctx != null && !ctx.isEmpty()) {
+                Validations.validateCtxMapKeys(ctx);
+            }
             this.ctx = ctx;
             return this;
         }

--- a/src/main/java/com/skyflow/serviceaccount/util/SignedDataTokens.java
+++ b/src/main/java/com/skyflow/serviceaccount/util/SignedDataTokens.java
@@ -13,6 +13,8 @@ import com.skyflow.utils.Utils;
 import com.skyflow.utils.logger.LogUtil;
 import io.jsonwebtoken.Jwts;
 
+import com.skyflow.utils.validations.Validations;
+
 import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.FileReader;
@@ -20,13 +22,14 @@ import java.security.PrivateKey;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 public class SignedDataTokens {
     private final File credentialsFile;
     private final String credentialsString;
     private final String credentialsType;
-    private final String ctx;
+    private final Object ctx;
     private final ArrayList<String> dataTokens;
     private final Integer timeToLive;
 
@@ -44,7 +47,7 @@ public class SignedDataTokens {
     }
 
     private static List<SignedDataTokenResponse> generateSignedTokenFromCredentialsFile(
-            File credentialsFile, ArrayList<String> dataTokens, Integer timeToLive, String context
+            File credentialsFile, ArrayList<String> dataTokens, Integer timeToLive, Object context
     ) throws SkyflowException {
         LogUtil.printInfoLog(InfoLogs.GENERATE_SIGNED_TOKENS_FROM_CREDENTIALS_FILE_TRIGGERED.getLog());
         List<SignedDataTokenResponse> responseToken;
@@ -69,7 +72,7 @@ public class SignedDataTokens {
     }
 
     private static List<SignedDataTokenResponse> generateSignedTokensFromCredentialsString(
-            String credentials, ArrayList<String> dataTokens, Integer timeToLive, String context
+            String credentials, ArrayList<String> dataTokens, Integer timeToLive, Object context
     ) throws SkyflowException {
         LogUtil.printInfoLog(InfoLogs.GENERATE_SIGNED_TOKENS_FROM_CREDENTIALS_STRING_TRIGGERED.getLog());
         List<SignedDataTokenResponse> responseToken;
@@ -89,7 +92,7 @@ public class SignedDataTokens {
     }
 
     private static List<SignedDataTokenResponse> generateSignedTokensFromCredentials(
-            JsonObject credentials, ArrayList<String> dataTokens, Integer timeToLive, String context
+            JsonObject credentials, ArrayList<String> dataTokens, Integer timeToLive, Object context
     ) throws SkyflowException {
         List<SignedDataTokenResponse> signedDataTokens = null;
         try {
@@ -122,8 +125,19 @@ public class SignedDataTokens {
 
     private static List<SignedDataTokenResponse> getSignedToken(
             String clientID, String keyID, PrivateKey pvtKey,
-            ArrayList<String> dataTokens, Integer timeToLive, String context
-    ) {
+            ArrayList<String> dataTokens, Integer timeToLive, Object context
+    ) throws SkyflowException {
+        // Validate and normalize context
+        Object validatedContext = context;
+        if (context instanceof Map) {
+            Map<?, ?> ctxMap = (Map<?, ?>) context;
+            if (ctxMap.isEmpty()) {
+                validatedContext = null;
+            } else {
+                Validations.validateCtxMapKeys(ctxMap);
+            }
+        }
+
         final Date createdDate = new Date();
         final Date expirationDate;
 
@@ -140,7 +154,7 @@ public class SignedDataTokens {
                     .claim("iat", (createdDate.getTime() / 1000))
                     .claim("key", keyID)
                     .claim("sub", clientID)
-                    .claim("ctx", context)
+                    .claim("ctx", validatedContext)
                     .claim("tok", dataToken)
                     .expiration(expirationDate)
                     .signWith(pvtKey, Jwts.SIG.RS256)
@@ -168,7 +182,7 @@ public class SignedDataTokens {
         private Integer timeToLive;
         private File credentialsFile;
         private String credentialsString;
-        private String ctx;
+        private Object ctx;
         private String credentialsType;
 
         private SignedDataTokensBuilder() {
@@ -191,6 +205,14 @@ public class SignedDataTokens {
         }
 
         public SignedDataTokensBuilder setCtx(String ctx) {
+            this.ctx = ctx;
+            return this;
+        }
+
+        public SignedDataTokensBuilder setCtx(Map<String, Object> ctx) throws SkyflowException {
+            if (ctx != null && !ctx.isEmpty()) {
+                Validations.validateCtxMapKeys(ctx);
+            }
             this.ctx = ctx;
             return this;
         }

--- a/src/main/java/com/skyflow/utils/Constants.java
+++ b/src/main/java/com/skyflow/utils/Constants.java
@@ -16,6 +16,7 @@ public final class Constants {
     public static final String SIGNED_DATA_TOKEN_PREFIX = "signed_token_";
     public static final String ORDER_ASCENDING = "ASCENDING";
     public static final String API_KEY_REGEX = "^sky-[a-zA-Z0-9]{5}-[a-fA-F0-9]{32}$";
+    public static final String CTX_MAP_KEY_REGEX = "^[a-zA-Z0-9_]+$";
     public static final String ENV_CREDENTIALS_KEY_NAME = "SKYFLOW_CREDENTIALS";
     public static final String SDK_NAME = "Skyflow Java SDK";
     public static final String DEFAULT_SDK_VERSION = "v2";

--- a/src/main/java/com/skyflow/utils/Utils.java
+++ b/src/main/java/com/skyflow/utils/Utils.java
@@ -47,28 +47,27 @@ public final class Utils {
         return sb.toString();
     }
 
-    @SuppressWarnings("unchecked")
     public static String generateBearerToken(Credentials credentials) throws SkyflowException {
         if (credentials.getPath() != null) {
             BearerToken.BearerTokenBuilder builder = BearerToken.builder()
                     .setCredentials(new File(credentials.getPath()))
                     .setRoles(credentials.getRoles());
-            Object ctx = credentials.getContextAsObject();
-            if (ctx instanceof Map) {
-                builder.setCtx((Map<String, Object>) ctx);
+            Map<String, Object> ctxMap = credentials.getContextAsMap();
+            if (ctxMap != null) {
+                builder.setCtx(ctxMap);
             } else {
-                builder.setCtx((String) ctx);
+                builder.setCtx(credentials.getContext());
             }
             return builder.build().getBearerToken();
         } else if (credentials.getCredentialsString() != null) {
             BearerToken.BearerTokenBuilder builder = BearerToken.builder()
                     .setCredentials(credentials.getCredentialsString())
                     .setRoles(credentials.getRoles());
-            Object ctx = credentials.getContextAsObject();
-            if (ctx instanceof Map) {
-                builder.setCtx((Map<String, Object>) ctx);
+            Map<String, Object> ctxMap = credentials.getContextAsMap();
+            if (ctxMap != null) {
+                builder.setCtx(ctxMap);
             } else {
-                builder.setCtx((String) ctx);
+                builder.setCtx(credentials.getContext());
             }
             return builder.build().getBearerToken();
         } else {

--- a/src/main/java/com/skyflow/utils/Utils.java
+++ b/src/main/java/com/skyflow/utils/Utils.java
@@ -47,21 +47,30 @@ public final class Utils {
         return sb.toString();
     }
 
+    @SuppressWarnings("unchecked")
     public static String generateBearerToken(Credentials credentials) throws SkyflowException {
         if (credentials.getPath() != null) {
-            return BearerToken.builder()
+            BearerToken.BearerTokenBuilder builder = BearerToken.builder()
                     .setCredentials(new File(credentials.getPath()))
-                    .setRoles(credentials.getRoles())
-                    .setCtx(credentials.getContext())
-                    .build()
-                    .getBearerToken();
+                    .setRoles(credentials.getRoles());
+            Object ctx = credentials.getContextAsObject();
+            if (ctx instanceof Map) {
+                builder.setCtx((Map<String, Object>) ctx);
+            } else {
+                builder.setCtx((String) ctx);
+            }
+            return builder.build().getBearerToken();
         } else if (credentials.getCredentialsString() != null) {
-            return BearerToken.builder()
+            BearerToken.BearerTokenBuilder builder = BearerToken.builder()
                     .setCredentials(credentials.getCredentialsString())
-                    .setRoles(credentials.getRoles())
-                    .setCtx(credentials.getContext())
-                    .build()
-                    .getBearerToken();
+                    .setRoles(credentials.getRoles());
+            Object ctx = credentials.getContextAsObject();
+            if (ctx instanceof Map) {
+                builder.setCtx((Map<String, Object>) ctx);
+            } else {
+                builder.setCtx((String) ctx);
+            }
+            return builder.build().getBearerToken();
         } else {
             return credentials.getToken();
         }

--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -42,7 +42,34 @@ import com.skyflow.vault.tokens.DetokenizeRequest;
 import com.skyflow.vault.tokens.TokenizeRequest;
 
 public class Validations {
+    private static final Pattern CTX_MAP_KEY_PATTERN = Pattern.compile("^[a-zA-Z0-9_]+$");
+
     private Validations() {
+    }
+
+    public static void validateCtxMapKeys(Map<?, ?> ctxMap) throws SkyflowException {
+        for (Object key : ctxMap.keySet()) {
+            if (key == null) {
+                LogUtil.printErrorLog(Utils.parameterizedString(
+                        ErrorLogs.INVALID_CTX_MAP_KEY.getLog(), "null"
+                ));
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(),
+                        Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "null"));
+            }
+            String keyStr = key.toString();
+            if (!CTX_MAP_KEY_PATTERN.matcher(keyStr).matches()) {
+                LogUtil.printErrorLog(Utils.parameterizedString(
+                        ErrorLogs.INVALID_CTX_MAP_KEY.getLog(), keyStr
+                ));
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(),
+                        Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), keyStr));
+            }
+            // Recursively validate nested maps
+            Object value = ctxMap.get(key);
+            if (value instanceof Map) {
+                validateCtxMapKeys((Map<?, ?>) value);
+            }
+        }
     }
 
     public static void validateVaultConfig(VaultConfig vaultConfig) throws SkyflowException {
@@ -162,7 +189,7 @@ public class Validations {
         String credentialsString = credentials.getCredentialsString();
         String token = credentials.getToken();
         String apiKey = credentials.getApiKey();
-        String context = credentials.getContext();
+        Object context = credentials.getContextAsObject();
         ArrayList<String> roles = credentials.getRoles();
 
         if (path != null) nonNullMembers++;
@@ -217,9 +244,16 @@ public class Validations {
                 }
             }
         }
-        if (context != null && context.trim().isEmpty()) {
-            LogUtil.printErrorLog(ErrorLogs.EMPTY_OR_NULL_CONTEXT.getLog());
-            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyContext.getMessage());
+        if (context != null) {
+            if (context instanceof String && ((String) context).trim().isEmpty()) {
+                LogUtil.printErrorLog(ErrorLogs.EMPTY_OR_NULL_CONTEXT.getLog());
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyContext.getMessage());
+            } else if (context instanceof Map && ((Map<?, ?>) context).isEmpty()) {
+                LogUtil.printErrorLog(ErrorLogs.EMPTY_OR_NULL_CONTEXT.getLog());
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyContext.getMessage());
+            } else if (context instanceof Map) {
+                validateCtxMapKeys((Map<?, ?>) context);
+            }
         }
     }
 

--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -42,7 +42,7 @@ import com.skyflow.vault.tokens.DetokenizeRequest;
 import com.skyflow.vault.tokens.TokenizeRequest;
 
 public class Validations {
-    private static final Pattern CTX_MAP_KEY_PATTERN = Pattern.compile("^[a-zA-Z0-9_]+$");
+    private static final Pattern CTX_MAP_KEY_PATTERN = Pattern.compile(Constants.CTX_MAP_KEY_REGEX);
 
     private Validations() {
     }

--- a/src/test/java/com/skyflow/config/CredentialsTests.java
+++ b/src/test/java/com/skyflow/config/CredentialsTests.java
@@ -3,6 +3,7 @@ package com.skyflow.config;
 import com.skyflow.errors.ErrorCode;
 import com.skyflow.errors.ErrorMessage;
 import com.skyflow.errors.SkyflowException;
+import com.skyflow.utils.Utils;
 import com.skyflow.utils.validations.Validations;
 import org.junit.Assert;
 import org.junit.Before;
@@ -10,6 +11,8 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class CredentialsTests {
     private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
@@ -258,6 +261,94 @@ public class CredentialsTests {
             Credentials credentials = new Credentials();
             credentials.setPath(path);
             credentials.setContext("");
+            Validations.validateCredentials(credentials);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(ErrorMessage.EmptyContext.getMessage(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testValidCredentialsWithMapContext() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("role", "admin");
+            mapContext.put("department", "engineering");
+            Credentials credentials = new Credentials();
+            credentials.setApiKey(validApiKey);
+            credentials.setContext(mapContext);
+            Validations.validateCredentials(credentials);
+            Assert.assertNull(credentials.getContext());
+            Assert.assertEquals(mapContext, credentials.getContextAsObject());
+        } catch (SkyflowException e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testInvalidCtxMapKeyWithHyphenInCredentials() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid-key", "value");
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            credentials.setContext(mapContext);
+            Validations.validateCredentials(credentials);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid-key"),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testInvalidCtxMapKeyWithDotInCredentials() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid.key", "value");
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            credentials.setContext(mapContext);
+            Validations.validateCredentials(credentials);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid.key"),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testInvalidCtxMapKeyWithSpaceInCredentials() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid key", "value");
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            credentials.setContext(mapContext);
+            Validations.validateCredentials(credentials);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid key"),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testEmptyMapContextInCredentials() {
+        try {
+            Credentials credentials = new Credentials();
+            credentials.setPath(path);
+            credentials.setContext(new HashMap<>());
             Validations.validateCredentials(credentials);
             Assert.fail(EXCEPTION_NOT_THROWN);
         } catch (SkyflowException e) {

--- a/src/test/java/com/skyflow/serviceaccount/util/BearerTokenTests.java
+++ b/src/test/java/com/skyflow/serviceaccount/util/BearerTokenTests.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class BearerTokenTests {
     private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
@@ -193,6 +195,94 @@ public class BearerTokenTests {
         } catch (SkyflowException e) {
             Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
             Assert.assertEquals(ErrorMessage.JwtInvalidFormat.getMessage(), e.getMessage());
+        }
+    }
+
+    @Test
+    public void testBearerTokenBuilderWithMapContext() {
+        try {
+            File file = new File(credentialsFilePath);
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("role", "admin");
+            mapContext.put("department", "engineering");
+            BearerToken.builder().setCredentials(file).setCtx(mapContext).setRoles(roles).build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testBearerTokenBuilderWithNestedMapContext() {
+        try {
+            File file = new File(credentialsFilePath);
+            Map<String, Object> nestedContext = new HashMap<>();
+            Map<String, Object> user = new HashMap<>();
+            user.put("role", "admin");
+            user.put("level", 5);
+            nestedContext.put("user", user);
+            nestedContext.put("project_id", "proj_123");
+            BearerToken.builder().setCredentials(file).setCtx(nestedContext).build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testBearerTokenBuilderWithMapContextAndCredentialsString() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("role", "admin");
+            BearerToken.builder().setCredentials(credentialsString).setCtx(mapContext).build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testBearerTokenWithInvalidCtxMapKeyContainingHyphen() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid-key", "value");
+            BearerToken.builder().setCtx(mapContext);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid-key"),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testBearerTokenWithInvalidCtxMapKeyContainingDot() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid.key", "value");
+            BearerToken.builder().setCtx(mapContext);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid.key"),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testBearerTokenWithInvalidCtxMapKeyContainingSpace() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid key", "value");
+            BearerToken.builder().setCtx(mapContext);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid key"),
+                    e.getMessage()
+            );
         }
     }
 

--- a/src/test/java/com/skyflow/serviceaccount/util/SignedDataTokensTests.java
+++ b/src/test/java/com/skyflow/serviceaccount/util/SignedDataTokensTests.java
@@ -10,6 +10,8 @@ import org.junit.Test;
 
 import java.io.File;
 import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Map;
 
 public class SignedDataTokensTests {
     private static final String INVALID_EXCEPTION_THROWN = "Should not have thrown any exception";
@@ -58,6 +60,100 @@ public class SignedDataTokensTests {
             Assert.fail(INVALID_EXCEPTION_THROWN);
         }
 
+    }
+
+    @Test
+    public void testSignedDataTokensBuilderWithMapContext() {
+        try {
+            File file = new File(credentialsFilePath);
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("role", "admin");
+            mapContext.put("department", "engineering");
+            SignedDataTokens.builder()
+                    .setCredentials(file).setCtx(mapContext).setDataTokens(dataTokens).setTimeToLive(ttl)
+                    .build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testSignedDataTokensBuilderWithNestedMapContext() {
+        try {
+            File file = new File(credentialsFilePath);
+            Map<String, Object> nestedContext = new HashMap<>();
+            Map<String, Object> user = new HashMap<>();
+            user.put("role", "admin");
+            user.put("level", 5);
+            nestedContext.put("user", user);
+            nestedContext.put("project_id", "proj_123");
+            SignedDataTokens.builder()
+                    .setCredentials(file).setCtx(nestedContext).setDataTokens(dataTokens).setTimeToLive(ttl)
+                    .build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testSignedDataTokensBuilderWithMapContextAndCredentialsString() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("role", "admin");
+            SignedDataTokens.builder()
+                    .setCredentials(credentialsString).setCtx(mapContext).setDataTokens(dataTokens).setTimeToLive(ttl)
+                    .build();
+        } catch (Exception e) {
+            Assert.fail(INVALID_EXCEPTION_THROWN);
+        }
+    }
+
+    @Test
+    public void testSignedDataTokensWithInvalidCtxMapKeyContainingHyphen() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid-key", "value");
+            SignedDataTokens.builder().setCtx(mapContext);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid-key"),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testSignedDataTokensWithInvalidCtxMapKeyContainingDot() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid.key", "value");
+            SignedDataTokens.builder().setCtx(mapContext);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid.key"),
+                    e.getMessage()
+            );
+        }
+    }
+
+    @Test
+    public void testSignedDataTokensWithInvalidCtxMapKeyContainingSpace() {
+        try {
+            Map<String, Object> mapContext = new HashMap<>();
+            mapContext.put("invalid key", "value");
+            SignedDataTokens.builder().setCtx(mapContext);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
+            Assert.assertEquals(
+                    Utils.parameterizedString(ErrorMessage.InvalidCtxMapKey.getMessage(), "invalid key"),
+                    e.getMessage()
+            );
+        }
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Add `setCtx(Map<String, Object>)` overloads to `BearerToken` and `SignedDataTokens` builders so the JWT `ctx` claim can be a nested JSON object (required for Conditional Data Access CEL expressions like `request.context.role == 'admin'`)
- Add `setContext(Map<String, Object>)` and `getContextAsObject()` to `Credentials` for high-level Skyflow client usage
- Fully backwards compatible — existing `setCtx(String)` and `setContext(String)` APIs unchanged

## Changes
- **Core**: `BearerToken.java`, `SignedDataTokens.java` — widen internal `ctx` field to `Object`, add `Map` overloads to builders
- **Config**: `Credentials.java` — add `setContext(Map)` setter and `getContextAsObject()` getter (preserves `getContext()` returning `String`)
- **Utils**: `Utils.java` — dispatch context to correct `setCtx` overload based on type
- **Validation**: `Validations.java` — validate empty `Map` context same as empty `String`
- **Tests**: 8 new unit tests across `BearerTokenTests`, `SignedDataTokensTests`, `CredentialsTests`
- **Samples**: Updated `BearerTokenGenerationWithContextExample` and `SignedTokenGenerationExample` with Map context examples
- **README**: Documented Conditional Data Access with CEL expressions, string vs. JSON object context usage

**Replaces #291** (which was created from a fork and couldn't run CI).

## Test plan
- [x] `mvn compile` — clean
- [x] `mvn test -Dtest=BearerTokenTests,SignedDataTokensTests,CredentialsTests` — 51 tests, 0 failures
- [x] Samples compile against locally installed SDK
- [ ] End-to-end test with a Skyflow vault using a Conditional Data Access policy

Refs SK-2679, DOCU-1438