### PR TITLE
SK-2703: resolve outdated libraries for java sdk

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,7 +35,7 @@
         <maven.compiler.source>8</maven.compiler.source>
         <maven.compiler.target>8</maven.compiler.target>
         <okhttp-version>4.12.0</okhttp-version>
-        <gson-version>2.10.1</gson-version>
+        <gson-version>2.13.2</gson-version>
         <gson-fire-version>1.9.0</gson-fire-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <okhttp-version>4.12.0</okhttp-version>
@@ -49,19 +49,19 @@
         <dependency>
             <groupId>com.fasterxml.jackson.core</groupId>
             <artifactId>jackson-databind</artifactId>
-            <version>2.18.6</version>
+            <version>2.21.2</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.17.2</version>
+            <version>2.21.1</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.17.2</version>
+            <version>2.21.2</version>
             <scope>compile</scope>
         </dependency>
         <!-- newly added v2 dependencies -->
@@ -99,7 +99,7 @@
         <dependency>
             <groupId>commons-codec</groupId>
             <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
+            <version>1.18.0</version>
         </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
@@ -181,7 +181,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
-                <version>3.2.5</version>
+                <version>3.5.5</version>
                 <configuration>
                     <useModulePath>false</useModulePath>
                     <includes>
@@ -215,7 +215,7 @@
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
-                <version>0.8.7</version>
+                <version>0.8.12</version>
                 <executions>
                     <execution>
                         <id>prepare-agent</id>


### PR DESCRIPTION
Why:
Several libraries in the Java SDK had available patch and minor version updates. Keeping dependencies up to date ensures the SDK benefits from bug fixes, performance improvements, and security patches without introducing breaking changes for clients.

Goal:
- Update all runtime and dev dependencies with safe patch/minor version bumps through pom.xml.
- Ensure no major version upgrades are included to avoid breaking changes.