### PR TITLE
Devesh/sk 2814 invoke connection fixes (#323)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>com.skyflow</groupId>
     <artifactId>skyflow-java</artifactId>
-    <version>2.1.0</version>
+    <version>3.0.0-beta.11-dev.c859136</version>
     <packaging>jar</packaging>
 
     <name>${project.groupId}:${project.artifactId}</name>

--- a/src/main/java/com/skyflow/utils/Constants.java
+++ b/src/main/java/com/skyflow/utils/Constants.java
@@ -40,7 +40,6 @@ public final class Constants {
     public static final String QUOTE = "\"";
 
     public static final class HttpUtilityExtra {
-        public static final String RAW_BODY_KEY = "__raw_body__";
         public static final String SDK_GENERATED_PREFIX = "SDK-Generated-";
         private HttpUtilityExtra() {}
     }

--- a/src/main/java/com/skyflow/utils/HttpUtility.java
+++ b/src/main/java/com/skyflow/utils/HttpUtility.java
@@ -13,6 +13,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 
 public final class HttpUtility {
 
@@ -56,9 +57,7 @@ public final class HttpUtility {
                     byte[] input = null;
                     String requestContentType = connection.getRequestProperty("content-type");
 
-                    if (params.has(Constants.HttpUtilityExtra.RAW_BODY_KEY) && params.size() == 1) {
-                        input = params.get(Constants.HttpUtilityExtra.RAW_BODY_KEY).getAsString().getBytes(StandardCharsets.UTF_8);
-                    } else if (requestContentType != null && requestContentType.contains("application/x-www-form-urlencoded")) {
+                    if (requestContentType != null && requestContentType.contains("application/x-www-form-urlencoded")) {
                         input = formatJsonToFormEncodedString(params).getBytes(StandardCharsets.UTF_8);
                     } else if (requestContentType != null && requestContentType.contains("multipart/form-data")) {
                         input = formatJsonToMultiPartFormDataString(params, boundary).getBytes(StandardCharsets.UTF_8);
@@ -73,7 +72,11 @@ public final class HttpUtility {
 
             int httpCode = connection.getResponseCode();
             String requestID = connection.getHeaderField("x-request-id");
-            HttpUtility.requestID = requestID != null ? requestID.split(",")[0] : null;
+            if (requestID != null) {
+                HttpUtility.requestID = requestID.split(",")[0];
+            } else {
+                HttpUtility.requestID = Constants.HttpUtilityExtra.SDK_GENERATED_PREFIX + UUID.randomUUID();
+            }
             Map<String, List<String>> responseHeaders = connection.getHeaderFields();
             Reader streamReader;
             if (httpCode > 299) {

--- a/src/main/java/com/skyflow/utils/Utils.java
+++ b/src/main/java/com/skyflow/utils/Utils.java
@@ -17,8 +17,6 @@ import org.apache.commons.codec.binary.Base64;
 import java.io.File;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.net.URLEncoder;
-import java.nio.charset.StandardCharsets;
 import java.security.KeyFactory;
 import java.security.NoSuchAlgorithmException;
 import java.security.PrivateKey;
@@ -121,12 +119,7 @@ public final class Utils {
             for (Map.Entry<String, String> entry : invokeConnectionRequest.getPathParams().entrySet()) {
                 String key = entry.getKey();
                 String value = entry.getValue();
-                try {
-                    String encodedValue = URLEncoder.encode(value, StandardCharsets.UTF_8.name());
-                    filledURL = new StringBuilder(filledURL.toString().replace(String.format(Constants.CURLY_PLACEHOLDER, key), encodedValue));
-                } catch (Exception e) {
-                    filledURL = new StringBuilder(filledURL.toString().replace(String.format(Constants.CURLY_PLACEHOLDER, key), value));
-                }
+                filledURL = new StringBuilder(filledURL.toString().replace(String.format(Constants.CURLY_PLACEHOLDER, key), value));
             }
         }
 
@@ -135,13 +128,7 @@ public final class Utils {
             for (Map.Entry<String, String> entry : invokeConnectionRequest.getQueryParams().entrySet()) {
                 String key = entry.getKey();
                 String value = entry.getValue();
-                try {
-                    String encodedKey = URLEncoder.encode(key, StandardCharsets.UTF_8.name());
-                    String encodedValue = URLEncoder.encode(value, StandardCharsets.UTF_8.name());
-                    filledURL.append(encodedKey).append("=").append(encodedValue).append("&");
-                } catch (Exception e) {
-                    filledURL.append(key).append("=").append(value).append("&");
-                }
+                filledURL.append(key).append("=").append(value).append("&");
             }
             filledURL = new StringBuilder(filledURL.substring(0, filledURL.length() - 1));
         }

--- a/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -10,7 +10,6 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import com.google.gson.Gson;
-import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.skyflow.config.ConnectionConfig;
 import com.skyflow.config.Credentials;
@@ -150,24 +149,12 @@ public class Validations {
             if (requestBody.getClass().equals(Object.class)) {
                 return;
             }
-            if (requestBody instanceof String) {
-                String bodyStr = (String) requestBody;
-                if (bodyStr.trim().isEmpty()) {
-                    LogUtil.printErrorLog(Utils.parameterizedString(
-                            ErrorLogs.EMPTY_REQUEST_BODY.getLog(), InterfaceName.INVOKE_CONNECTION.getName()));
-                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyRequestBody.getMessage());
-                }
-            } else {
-                Gson gson = new Gson();
-                JsonElement bodyElement = gson.toJsonTree(requestBody);
-                if (bodyElement.isJsonObject()) {
-                    JsonObject bodyObject = bodyElement.getAsJsonObject();
-                    if (bodyObject.isEmpty()) {
-                        LogUtil.printErrorLog(Utils.parameterizedString(
-                                ErrorLogs.EMPTY_REQUEST_BODY.getLog(), InterfaceName.INVOKE_CONNECTION.getName()));
-                        throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyRequestBody.getMessage());
-                    }
-                }
+            Gson gson = new Gson();
+            JsonObject bodyObject = gson.toJsonTree(requestBody).getAsJsonObject();
+            if (bodyObject.isEmpty()) {
+                LogUtil.printErrorLog(Utils.parameterizedString(
+                        ErrorLogs.EMPTY_REQUEST_BODY.getLog(), InterfaceName.INVOKE_CONNECTION.getName()));
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyRequestBody.getMessage());
             }
         }
     }

--- a/src/main/java/com/skyflow/vault/controller/ConnectionController.java
+++ b/src/main/java/com/skyflow/vault/controller/ConnectionController.java
@@ -55,26 +55,11 @@ public final class ConnectionController extends ConnectionClient {
             Object requestBodyObject = invokeConnectionRequest.getRequestBody();
 
             if (requestBodyObject != null) {
-                if (requestBodyObject instanceof String) {
-                    String contentType = headers.getOrDefault("content-type", "");
-                    if (!contentType.isEmpty() && !contentType.toLowerCase().contains("application/json")) {
-                        requestBody = new JsonObject();
-                        requestBody.addProperty(Constants.HttpUtilityExtra.RAW_BODY_KEY, (String) requestBodyObject);
-                    } else {
-                        try {
-                            requestBody = convertObjectToJson(requestBodyObject);
-                        } catch (Exception e) {
-                            LogUtil.printErrorLog(ErrorLogs.INVALID_REQUEST_HEADERS.getLog());
-                            throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidRequestBody.getMessage());
-                        }
-                    }
-                } else {
-                    try {
-                        requestBody = convertObjectToJson(requestBodyObject);
-                    } catch (Exception e) {
-                        LogUtil.printErrorLog(ErrorLogs.INVALID_REQUEST_HEADERS.getLog());
-                        throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidRequestBody.getMessage());
-                    }
+                try {
+                    requestBody = convertObjectToJson(requestBodyObject);
+                } catch (Exception e) {
+                    LogUtil.printErrorLog(ErrorLogs.INVALID_REQUEST_HEADERS.getLog());
+                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.InvalidRequestBody.getMessage());
                 }
             }
 

--- a/src/test/java/com/skyflow/utils/HttpUtilityTests.java
+++ b/src/test/java/com/skyflow/utils/HttpUtilityTests.java
@@ -167,7 +167,7 @@ public class HttpUtilityTests {
             params.addProperty("key", "value");
             String response = httpUtility.sendRequest("GET", url, params, headers);
             Assert.assertEquals(expected, response);
-            Assert.assertNull(HttpUtility.getRequestID());
+            Assert.assertNotNull(HttpUtility.getRequestID());
         } catch (Exception e) {
             fail(INVALID_EXCEPTION_THROWN);
         }

--- a/src/test/java/com/skyflow/vault/controller/ConnectionControllerTests.java
+++ b/src/test/java/com/skyflow/vault/controller/ConnectionControllerTests.java
@@ -138,44 +138,6 @@ public class ConnectionControllerTests {
     }
 
     @Test
-    public void testInvoke_successWithStringBodyAndJsonContentType() throws Exception {
-        when(HttpUtility.sendRequest(anyString(), any(URL.class), any(), any()))
-                .thenReturn("{\"parsed\":true}");
-        when(HttpUtility.getRequestID()).thenReturn(REQUEST_ID);
-
-        Map<String, String> headers = new HashMap<>();
-        headers.put("content-type", "application/json");
-
-        InvokeConnectionRequest request = InvokeConnectionRequest.builder()
-                .method(RequestMethod.POST)
-                .requestHeaders(headers)
-                .requestBody("{\"key\":\"value\"}")
-                .build();
-        InvokeConnectionResponse response = controller.invoke(request);
-
-        Assert.assertNotNull(response);
-    }
-
-    @Test
-    public void testInvoke_successWithStringBodyAndNonJsonContentType() throws Exception {
-        when(HttpUtility.sendRequest(anyString(), any(URL.class), any(), any()))
-                .thenReturn("ok");
-        when(HttpUtility.getRequestID()).thenReturn(REQUEST_ID);
-
-        Map<String, String> headers = new HashMap<>();
-        headers.put("content-type", "text/plain");
-
-        InvokeConnectionRequest request = InvokeConnectionRequest.builder()
-                .method(RequestMethod.POST)
-                .requestHeaders(headers)
-                .requestBody("raw body content")
-                .build();
-        InvokeConnectionResponse response = controller.invoke(request);
-
-        Assert.assertNotNull(response);
-    }
-
-    @Test
     public void testInvoke_successWithObjectBody() throws Exception {
         when(HttpUtility.sendRequest(anyString(), any(URL.class), any(), any()))
                 .thenReturn("{\"result\":\"ok\"}");
@@ -361,20 +323,6 @@ public class ConnectionControllerTests {
         } catch (SkyflowException e) {
             Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
             Assert.assertEquals(ErrorMessage.EmptyQueryParams.getMessage(), e.getMessage());
-        }
-    }
-
-    @Test
-    public void testInvoke_emptyStringBodyThrowsSkyflowException() {
-        try {
-            InvokeConnectionRequest request = InvokeConnectionRequest.builder()
-                    .requestBody("   ")
-                    .build();
-            controller.invoke(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
-        } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(ErrorMessage.EmptyRequestBody.getMessage(), e.getMessage());
         }
     }
 


### PR DESCRIPTION
* Revert "test: fix testSendRequestWithNullRequestId to assert null requestId"

This reverts commit 8c292d2b2661956beac305aea3fc201176f02a9e.

* Revert "fix: do not generate SDK-side requestId when server omits x-request-id header"

This reverts commit 2740de4c22592d208b253f2763136d26b070e4ce.

* revert: remove URL encoding and raw body from InvokeConnection

URL encoding path/query params is a breaking change for users who pre-encode values (double-encoding), and Go SDK v1/v2 does raw substitution with no encoding — keep consistent.

Raw string body support is not confirmed by the Connections API docs; the gateway needs structured (JSON/form) bodies for token replacement, so raw strings would forward tokens unreplaced. Remove to avoid misleading users.



---------

Start with a concise summary of the PR. The first three sections are required. The questions present in each section is there to help you guide you what to add. They are meant to be overwritten by your comments.
## Why
- Why are you making the change?
- What is the underlying issue that you are trying to case, in case of fix?
- Why is it needed by the feature you are working on?
- What is the intent behind making the change?

## Goal
- What is the intended outcome?
- What part of the feature should start working?
- What are the non-goals or will be covered in future PR?

## Testing
- How was the code tested?
- If you haven't written unit tests, why?
- What more testing is needed? Do you intend to manually test it after deployment?
- Do you have any concerns if this changed is released to prod?

## Tech debt
- Is the PR adding to tech debt in any way?
- Are you addressing some Tech debt in this PR?
- If both the above are false, feel free to remove this section.