### PR TITLE
SK-2871: Upgrade and prune Java dependencies

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,8 @@
         <maven.compiler.target>8</maven.compiler.target>
         <okhttp-version>4.12.0</okhttp-version>
         <gson-version>2.10.1</gson-version>
-        <gson-fire-version>1.9.0</gson-fire-version>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <okhttp-version>4.12.0</okhttp-version>
         <junit-version>4.13.2</junit-version>
-        <javax-xml-bind-version>2.3.1</javax-xml-bind-version>
-        <jakarta-annotation-version>1.3.5</jakarta-annotation-version>
         <sdk.version>${project.version}</sdk.version>
     </properties>
 
@@ -55,30 +51,20 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jdk8</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.6</version>
             <scope>compile</scope>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-jsr310</artifactId>
-            <version>2.17.2</version>
+            <version>2.18.6</version>
             <scope>compile</scope>
         </dependency>
         <!-- newly added v2 dependencies -->
         <dependency>
             <groupId>io.github.cdimascio</groupId>
             <artifactId>dotenv-java</artifactId>
-            <version>2.2.0</version>
-        </dependency>
-        <dependency>
-            <groupId>com.google.code.findbugs</groupId>
-            <artifactId>jsr305</artifactId>
-            <version>3.0.2</version>
-        </dependency>
-        <dependency>
-            <groupId>io.gsonfire</groupId>
-            <artifactId>gson-fire</artifactId>
-            <version>${gson-fire-version}</version>
+            <version>3.2.0</version>
         </dependency>
         <dependency>
             <groupId>com.google.code.gson</groupId>
@@ -90,32 +76,11 @@
             <artifactId>okhttp</artifactId>
             <version>${okhttp-version}</version>
         </dependency>
-        <dependency>
-            <groupId>com.squareup.okhttp3</groupId>
-            <artifactId>logging-interceptor</artifactId>
-            <version>${okhttp-version}</version>
-        </dependency>
         <!-- existing dependencies -->
-        <dependency>
-            <groupId>commons-codec</groupId>
-            <artifactId>commons-codec</artifactId>
-            <version>1.15</version>
-        </dependency>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>
             <artifactId>jjwt</artifactId>
             <version>0.12.6</version>
-        </dependency>
-        <dependency>
-            <groupId>jakarta.annotation</groupId>
-            <artifactId>jakarta.annotation-api</artifactId>
-            <version>${jakarta-annotation-version}</version>
-            <scope>provided</scope>
-        </dependency>
-        <dependency>
-            <groupId>javax.xml.bind</groupId>
-            <artifactId>jaxb-api</artifactId>
-            <version>${javax-xml-bind-version}</version>
         </dependency>
         <!-- existing test dependencies -->
         <dependency>

--- a/src/main/java/com/skyflow/serviceaccount/util/Token.java
+++ b/src/main/java/com/skyflow/serviceaccount/util/Token.java
@@ -9,7 +9,7 @@ import com.skyflow.errors.SkyflowException;
 import com.skyflow.logs.ErrorLogs;
 import com.skyflow.logs.InfoLogs;
 import com.skyflow.utils.logger.LogUtil;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Date;
@@ -40,7 +40,7 @@ public class Token {
             LogUtil.printErrorLog(ErrorLogs.INVALID_BEARER_TOKEN.getLog());
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.JwtDecodeError.getMessage());
         }
-        byte[] decodedBytes = Base64.decodeBase64(split[1]);
+        byte[] decodedBytes = Base64.getUrlDecoder().decode(split[1]);
         return JsonParser.parseString(new String(decodedBytes, StandardCharsets.UTF_8)).getAsJsonObject();
     }
 }

--- a/src/main/java/com/skyflow/utils/Utils.java
+++ b/src/main/java/com/skyflow/utils/Utils.java
@@ -12,7 +12,7 @@ import com.skyflow.logs.InfoLogs;
 import com.skyflow.serviceaccount.util.BearerToken;
 import com.skyflow.utils.logger.LogUtil;
 import com.skyflow.vault.connection.InvokeConnectionRequest;
-import org.apache.commons.codec.binary.Base64;
+import java.util.Base64;
 
 import java.io.File;
 import java.net.MalformedURLException;
@@ -90,7 +90,7 @@ public final class Utils {
             privateKeyContent = privateKeyContent.replace(PKCS8PrivateFooter, "");
             privateKeyContent = privateKeyContent.replace("\n", "");
             privateKeyContent = privateKeyContent.replace("\r\n", "");
-            privateKey = parsePkcs8PrivateKey(Base64.decodeBase64(privateKeyContent));
+            privateKey = parsePkcs8PrivateKey(Base64.getDecoder().decode(privateKeyContent));
         } else {
             LogUtil.printErrorLog(ErrorLogs.JWT_INVALID_FORMAT.getLog());
             throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.JwtInvalidFormat.getMessage());


### PR DESCRIPTION
- Bump jackson-datatype-jdk8/jsr310 2.17.2 -> 2.18.6 (align with jackson-databind)
- Bump dotenv-java 2.2.0 -> 3.2.0
- Migrate commons-codec Base64 -> java.util.Base64 (Token, Utils); drop commons-codec
- Remove unused compile-scoped deps: jsr305, gson-fire, logging-interceptor, jaxb-api, jakarta.annotation-api, and their orphaned version properties

Verified: mvn clean test compiles clean; the 5 remaining failures are pre-existing env-dependent tests (require local .env/credentials) and also fail on clean HEAD.
 