### PR TITLE
SK-2955: Align upsert/upsertType with Flow-DB changes (docs, tests, error-message cleanup)

### DIFF
--- a/README.md
+++ b/README.md
@@ -260,8 +260,11 @@ public class InsertSchema {
 **Note**:
 - The table name can be specified either at the request level `InsertRequest` or at the record level `InsertRecord`, but not both.
 - If table name is not specified at the request level `InsertRequest`, then it must be specified in all record objects.
-- If table name is specified at the request level `InsertRequest`, then upsert must also be specified at the request level.
-- If table name is specified at the record level `InsertRecord`, then upsert must also be specified at the record level `InsertRecord`.
+- Upsert must be specified in the same place as the table name: if table name is specified at the request level `InsertRequest`, specify upsert at the request level; if table name is specified at the record level `InsertRecord`, specify upsert at the record level `InsertRecord`.
+- `upsertType` is optional and can be set alongside `upsert` at either the request level or the record level (matching the table/upsert placement):
+    - `UpsertType.UPDATE` — updates only the columns provided in the request on the matched row; other existing columns are retained.
+    - `UpsertType.REPLACE` — replaces the matched row with the provided values; columns not provided are cleared.
+    - If `upsertType` is not specified, the vault applies the default of `UPDATE`.
 
 ### An [example](https://github.com/skyflowapi/skyflow-java/blob/v3/samples/src/main/java/com/example/vault/BulkInsertSync.java) of a sync bulkInsert call
 

--- a/samples/pom.xml
+++ b/samples/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.skyflow</groupId>
             <artifactId>skyflow-java</artifactId>
-            <version>3.0.0-beta.6</version>
+            <version>3.0.0-beta.11</version>
         </dependency>
 
     </dependencies>

--- a/samples/src/main/java/com/example/vault/BulkMultiTableInsertAsync.java
+++ b/samples/src/main/java/com/example/vault/BulkMultiTableInsertAsync.java
@@ -5,7 +5,6 @@ import com.skyflow.config.Credentials;
 import com.skyflow.config.VaultConfig;
 import com.skyflow.enums.Env;
 import com.skyflow.enums.LogLevel;
-import com.skyflow.enums.UpsertType;
 import com.skyflow.vault.data.InsertRecord;
 import com.skyflow.vault.data.InsertRequest;
 import com.skyflow.vault.data.InsertResponse;
@@ -59,7 +58,8 @@ public class BulkMultiTableInsertAsync {
                     .data(recordData1)
                     .table("<YOUR_TABLE_NAME>")
                     .upsert(upsertColumns)
-                    .upsertType(UpsertType.UPDATE)
+                    // upsertType is optional; when omitted the vault defaults to UpsertType.UPDATE.
+                    // Set .upsertType(UpsertType.REPLACE) to replace the matched row instead.
                     .build();
 
             // Step 5: Prepare second record for insertion

--- a/samples/src/main/java/com/example/vault/BulkMultiTableInsertSync.java
+++ b/samples/src/main/java/com/example/vault/BulkMultiTableInsertSync.java
@@ -5,7 +5,6 @@ import com.skyflow.config.Credentials;
 import com.skyflow.config.VaultConfig;
 import com.skyflow.enums.Env;
 import com.skyflow.enums.LogLevel;
-import com.skyflow.enums.UpsertType;
 import com.skyflow.errors.SkyflowException;
 import com.skyflow.vault.data.InsertRecord;
 import com.skyflow.vault.data.InsertRequest;
@@ -58,7 +57,8 @@ public class BulkMultiTableInsertSync {
                     .data(recordData1)
                     .table("<YOUR_TABLE_NAME>")
                     .upsert(upsertColumns)
-                    .upsertType(UpsertType.UPDATE)
+                    // upsertType is optional; when omitted the vault defaults to UpsertType.UPDATE.
+                    // Set .upsertType(UpsertType.REPLACE) to replace the matched row instead.
                     .build();
 
             // Step 5: Prepare second record for insertion

--- a/v3/src/main/java/com/skyflow/utils/validations/Validations.java
+++ b/v3/src/main/java/com/skyflow/utils/validations/Validations.java
@@ -73,30 +73,15 @@ public class Validations extends BaseValidations {
                 }
             }
         }
-        // upsert check 1
-        if (insertRequest.getTable() != null && !table.trim().isEmpty()){ // if table name specified at both place
-            for (InsertRecord record : records) {
-                if (record.getUpsert() != null && record.getUpsert().isEmpty()) {
-                    LogUtil.printErrorLog(Utils.parameterizedString(
-                            ErrorLogs.EMPTY_UPSERT_VALUES.getLog(), InterfaceName.INSERT.getName()
-                    ));
-                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyUpsertValues.getMessage());
-                }
-                if (record.getUpsert() != null && !record.getUpsert().isEmpty()){
-                    LogUtil.printErrorLog(Utils.parameterizedString(
-                            ErrorLogs.UPSERT_TABLE_REQUEST_AT_RECORD_LEVEL.getLog(), InterfaceName.INSERT.getName()
-                    ));
-                    throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.UpsertTableRequestAtRecordLevel.getMessage());
-                }
-            }
-        }
-        // upsert check 2
-        if (insertRequest.getTable() == null || table.trim().isEmpty()){
-            if (insertRequest.getUpsert() != null && !insertRequest.getUpsert().isEmpty()){
+        // Upsert placement (request level vs record level) is validated by the backend,
+        // which returns the authoritative error message. The SDK only guards against
+        // empty upsert column lists.
+        for (InsertRecord record : records) {
+            if (record.getUpsert() != null && record.getUpsert().isEmpty()) {
                 LogUtil.printErrorLog(Utils.parameterizedString(
-                        ErrorLogs.UPSERT_TABLE_REQUEST_AT_REQUEST_LEVEL.getLog(), InterfaceName.INSERT.getName()
+                        ErrorLogs.EMPTY_UPSERT_VALUES.getLog(), InterfaceName.INSERT.getName()
                 ));
-                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.UpsertTableRequestAtRequestLevel.getMessage());
+                throw new SkyflowException(ErrorCode.INVALID_INPUT.getCode(), ErrorMessage.EmptyUpsertValues.getMessage());
             }
         }
 

--- a/v3/src/test/java/com/skyflow/VaultClientTests.java
+++ b/v3/src/test/java/com/skyflow/VaultClientTests.java
@@ -280,6 +280,75 @@ public class VaultClientTests {
     }
 
     @Test
+    public void testUpsertAtRequestLevelWithoutUpsertTypeOmitsUpdateType() {
+        // When upsertType is not specified, the SDK must not send updateType so the
+        // backend applies its default (UPDATE).
+        Map<String, Object> data = new HashMap<>();
+        data.put("key", "value");
+        InsertRecord record = InsertRecord.builder().data(data).build();
+        ArrayList<InsertRecord> records = new ArrayList<>();
+        records.add(record);
+
+        com.skyflow.vault.data.InsertRequest request =
+                com.skyflow.vault.data.InsertRequest.builder()
+                        .records(records)
+                        .upsert(Arrays.asList("col1"))
+                        .build();
+
+        V1InsertRequest result = vaultClient.getBulkInsertRequestBody(request, vaultConfig);
+        Assert.assertNotNull(result.getUpsert());
+        Assert.assertEquals("col1", result.getUpsert().get().getUniqueColumns().get().get(0));
+        Assert.assertFalse(result.getUpsert().get().getUpdateType().isPresent());
+    }
+
+    @Test
+    public void testUpsertAtRecordLevelWithoutUpsertTypeOmitsUpdateType() {
+        // When upsertType is not specified at the record level, the SDK must not send
+        // updateType so the backend applies its default (UPDATE).
+        Map<String, Object> data = new HashMap<>();
+        data.put("key", "value");
+        InsertRecord record = InsertRecord.builder().data(data).upsert(Arrays.asList("col2")).build();
+        ArrayList<InsertRecord> records = new ArrayList<>();
+        records.add(record);
+
+        com.skyflow.vault.data.InsertRequest request =
+                com.skyflow.vault.data.InsertRequest.builder()
+                        .records(records)
+                        .build();
+
+        V1InsertRequest result = vaultClient.getBulkInsertRequestBody(request, vaultConfig);
+        Assert.assertNotNull(result.getRecords().get().get(0).getUpsert());
+        Assert.assertEquals("col2", result.getRecords().get().get(0).getUpsert().get().getUniqueColumns().get().get(0));
+        Assert.assertFalse(result.getRecords().get().get(0).getUpsert().get().getUpdateType().isPresent());
+    }
+
+    @Test
+    public void testUpsertTypeAtBothRequestAndRecordLevelSerializesBoth() {
+        // The SDK serializes updateType wherever it is set; the backend rejects the
+        // both-levels combination. This asserts the SDK does not silently drop either.
+        Map<String, Object> data = new HashMap<>();
+        data.put("key", "value");
+        InsertRecord record = InsertRecord.builder()
+                .data(data)
+                .upsert(Arrays.asList("col2"))
+                .upsertType(UpsertType.UPDATE)
+                .build();
+        ArrayList<InsertRecord> records = new ArrayList<>();
+        records.add(record);
+
+        com.skyflow.vault.data.InsertRequest request =
+                com.skyflow.vault.data.InsertRequest.builder()
+                        .records(records)
+                        .upsert(Arrays.asList("col1"))
+                        .upsertType(UpsertType.REPLACE)
+                        .build();
+
+        V1InsertRequest result = vaultClient.getBulkInsertRequestBody(request, vaultConfig);
+        Assert.assertEquals("REPLACE", result.getUpsert().get().getUpdateType().get().name());
+        Assert.assertEquals("UPDATE", result.getRecords().get().get(0).getUpsert().get().getUpdateType().get().name());
+    }
+
+    @Test
     public void testSetBearerTokenWhenTokenIsNull() throws Exception {
         Credentials credentials = new Credentials();
         credentials.setApiKey("sky-ab123-abcd1234cdef1234abcd4321cdef4321");

--- a/v3/src/test/java/com/skyflow/utils/validations/ValidationsTests.java
+++ b/v3/src/test/java/com/skyflow/utils/validations/ValidationsTests.java
@@ -75,7 +75,8 @@ public class ValidationsTests {
     }
 
     @Test
-    public void validateInsertRequest_upsertAtRecordLevel_throws() {
+    public void validateInsertRequest_upsertAtRecordLevelWithTableAtRequestLevel_deferredToBackend() throws SkyflowException {
+        // Upsert placement is no longer validated client-side; the backend owns the rule.
         ArrayList<InsertRecord> records = new ArrayList<>();
         records.add(InsertRecord.builder()
                 .table(null)
@@ -85,12 +86,12 @@ public class ValidationsTests {
                 .table("requestTable")
                 .records(records)
                 .build();
-        assertSkyflowException(() -> Validations.validateInsertRequest(request),
-                ErrorMessage.UpsertTableRequestAtRecordLevel.getMessage());
+        Validations.validateInsertRequest(request);
     }
 
     @Test
-    public void validateInsertRequest_upsertAtRequestLevelWithoutTable_throws() {
+    public void validateInsertRequest_upsertAtRequestLevelWithTableAtRecordLevel_deferredToBackend() throws SkyflowException {
+        // Upsert placement is no longer validated client-side; the backend owns the rule.
         ArrayList<InsertRecord> records = new ArrayList<>();
         records.add(InsertRecord.builder().table("recordTable").build());
         InsertRequest request = InsertRequest.builder()
@@ -98,8 +99,7 @@ public class ValidationsTests {
                 .upsert(Collections.singletonList("key"))
                 .records(records)
                 .build();
-        assertSkyflowException(() -> Validations.validateInsertRequest(request),
-                ErrorMessage.UpsertTableRequestAtRequestLevel.getMessage());
+        Validations.validateInsertRequest(request);
     }
 
     @Test

--- a/v3/src/test/java/com/skyflow/vault/data/InsertTests.java
+++ b/v3/src/test/java/com/skyflow/vault/data/InsertTests.java
@@ -326,6 +326,9 @@ public class InsertTests {
     }
 }
 
+   // Upsert placement (request vs record level) is validated by the backend, not the SDK.
+   // The SDK must accept these combinations and let the backend return the authoritative error.
+
    @Test
    public void testUpsertSpecifiedAtBothRequestAndRecordLevel() {
     InsertRecord record = InsertRecord.builder().data(valueMap).upsert(upsert).build();
@@ -333,13 +336,8 @@ public class InsertTests {
     InsertRequest request = InsertRequest.builder().table(table).records(values).upsert(upsert).build();
     try {
         Validations.validateInsertRequest(request);
-        Assert.fail(EXCEPTION_NOT_THROWN);
     } catch (SkyflowException e) {
-        Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-        Assert.assertEquals(
-            Utils.parameterizedString(ErrorMessage.UpsertTableRequestAtRecordLevel.getMessage(), Constants.SDK_PREFIX),
-            e.getMessage()
-        );
+        Assert.fail(INVALID_EXCEPTION_THROWN);
     }
 }
 
@@ -350,13 +348,8 @@ public class InsertTests {
     InsertRequest request = InsertRequest.builder().table(table).records(values).build();
     try {
         Validations.validateInsertRequest(request);
-        Assert.fail(EXCEPTION_NOT_THROWN);
     } catch (SkyflowException e) {
-        Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-        Assert.assertEquals(
-            Utils.parameterizedString(ErrorMessage.UpsertTableRequestAtRecordLevel.getMessage(), Constants.SDK_PREFIX),
-            e.getMessage()
-        );
+        Assert.fail(INVALID_EXCEPTION_THROWN);
     }
 }
 
@@ -367,13 +360,8 @@ public class InsertTests {
     InsertRequest request = InsertRequest.builder().records(values).upsert(upsert).build();
     try {
         Validations.validateInsertRequest(request);
-        Assert.fail(EXCEPTION_NOT_THROWN);
     } catch (SkyflowException e) {
-        Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-        Assert.assertEquals(
-            Utils.parameterizedString(ErrorMessage.UpsertTableRequestAtRequestLevel.getMessage(), Constants.SDK_PREFIX),
-            e.getMessage()
-        );
+        Assert.fail(INVALID_EXCEPTION_THROWN);
     }
 }
 
@@ -387,13 +375,8 @@ public class InsertTests {
         InsertRequest request = InsertRequest.builder().table("").records(values).upsert(upsert).build();
         try {
             Validations.validateInsertRequest(request);
-            Assert.fail(EXCEPTION_NOT_THROWN);
         } catch (SkyflowException e) {
-            Assert.assertEquals(ErrorCode.INVALID_INPUT.getCode(), e.getHttpCode());
-            Assert.assertEquals(
-                    Utils.parameterizedString(ErrorMessage.UpsertTableRequestAtRequestLevel.getMessage(), Constants.SDK_PREFIX),
-                    e.getMessage()
-            );
+            Assert.fail(INVALID_EXCEPTION_THROWN);
         }
     }
 


### PR DESCRIPTION
## Summary
Follow-up to CJP-410 / CUST-4294 (Nykaa). The original report — record-level
`upsertType.UPDATE` behaving like `REPLACE` — was a **Flow-DB (vault) bug**, now
fixed server-side. Flow-DB also now defaults record-level upsert to **UPDATE**
(previously REPLACE) and owns upsert-placement validation.

**No SDK contract change or core-logic fix required.** The SDK already serializes
record-level `upsertType` into `records[].upsert.updateType` and omits `updateType`
entirely when unset, so the new server-side default applies. This PR covers the
remaining docs, tests, and error-message hygiene.

Jira: https://skyflow.atlassian.net/browse/SK-2955

## Changes
- **README** — document that `upsertType` is optional, that the default is now
  `UPDATE` (applied by the backend), and the `UPDATE` vs `REPLACE` semantics.
- **Samples** — drop the now-redundant explicit `upsertType(UpsertType.UPDATE)`
  (it's the default) in `BulkMultiTableInsertSync`/`BulkMultiTableInsertAsync`,
  with a clarifying comment; removed the unused `UpsertType` import. `REPLACE`
  samples left unchanged (REPLACE is meaningful, non-default).
- **Validation** (`Validations.java`) — defer upsert *placement* checks
  (request- vs record-level) to the backend, which returns the authoritative
  message. The SDK now only guards against empty upsert column lists.
- **Tests** — add coverage for:
  - request-level upsert without `upsertType` → `updateType` omitted (default-UPDATE)
  - record-level upsert without `upsertType` → `updateType` omitted (default-UPDATE)
  - `upsertType` at both request and record level → both serialized (backend rejects)
  - updated `ValidationsTests` / `InsertTests` to reflect that placement is no
    longer validated client-side.
- **samples/pom.xml** — bump SDK dependency to `3.0.0-beta.11`.

## Testing
- `mvn test` (v3): all upsert-related tests pass. (`testSetBearerTokenWithEnvCredentials`
  is environmental — needs a local `.env` `SKYFLOW_CREDENTIALS` — and is unrelated.)
- `mvn compile` (samples): passes.

## Acceptance criteria
- [x] README + samples reflect optional `upsertType` and the new UPDATE default
- [x] Client-side validation messages deferred to backend
- [x] New unit tests pass for the scenarios above
- [ ] Verified against blitz once vault changes are released (manual, pending vault release)
