### PR TITLE
Fix release branch resolution picking stale feature branches

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -67,7 +67,7 @@ jobs:
         if: ${{ inputs.tag == 'beta' || inputs.tag == 'public' }} 
         run: |
           TAG_COMMIT=$(git rev-list -n 1 ${{ github.ref_name }})
-          BRANCH_NAME=$(git branch -r --contains $TAG_COMMIT | grep -o 'origin/.*' | sed 's|origin/||' | head -n 1)
+          BRANCH_NAME=$(git for-each-ref --points-at="$TAG_COMMIT" --format='%(refname:short)' refs/remotes/origin | grep -v '/HEAD$' | sed 's#^origin/##' | head -n 1)
           if [ -z "$BRANCH_NAME" ]; then
             echo "Error: Could not resolve branch for the tag."
             exit 1


### PR DESCRIPTION
## Summary
- The "Resolve Branch for the Tagged Commit" step in `shared-build-and-deploy.yml` used `git branch -r --contains $TAG_COMMIT`, which matches any remote branch that has the tag commit as an ancestor — not just the branch the tag was cut from.
- Long-lived or merged feature branches retain that ancestry indefinitely, and `git branch -r` sorts alphabetically, so `head -n 1` could pick the wrong branch (e.g. a stale `SK-2967-...` branch instead of `main`) on a recent public release.
- That wrong branch then caused `git checkout $BRANCH_NAME` in the "Commit changes" step to fail, since its `pom.xml` differed from the uncommitted version bump on the tag commit.
- Fix: use `git for-each-ref --points-at="$TAG_COMMIT"` to match only the branch whose tip is exactly the tag commit, filtering out the `origin/HEAD` symref entry.
