### PR TITLE
SK-3002 Fix release workflow: v3 branch/path ambiguity

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -103,7 +103,7 @@ jobs:
           git config user.email ${{ github.actor }}@users.noreply.github.com
 
           if [[ "${{ inputs.tag }}" == "beta" || "${{ inputs.tag }}" == "public" ]]; then
-            git checkout ${{ env.branch_name }}
+            git switch ${{ env.branch_name }}
           fi
 
           git add v3/pom.xml


### PR DESCRIPTION
## Problem

The release workflow (`beta`/`public`) failed in the **Commit changes** step:

```
fatal: 'v3' could be both a local file and a tracking branch.
Please use -- (and optionally --no-guess) to disambiguate
Error: Process completed with exit code 128.
```

**Root cause:** the step ran `git checkout ${{ env.branch_name }}` (i.e. `git checkout v3`). Because the repo now contains a `v3/` directory (see the `git add v3/pom.xml` line right below), the argument `v3` is ambiguous between the **branch** `v3` and the **path** `v3/`, so git bails out.

## Fix

Use `git switch` instead of `git checkout` in `.github/workflows/shared-build-and-deploy.yml`. `git switch` only ever operates on branches, so the branch/path collision cannot occur.

```diff
- git checkout ${{ env.branch_name }}
+ git switch ${{ env.branch_name }}
```

The `git push origin ${{ env.branch_name }}` lines are unaffected — push refspecs are not ambiguous with paths.

🤖 Generated with [Claude Code](https://claude.com/claude-code)