### PR TITLE
SK-2986 use admin service-account PAT for release version-bump push

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -50,6 +50,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          # PAT of the skyflow-service-it admin service account. Persisted by
+          # checkout and reused for the automated version-bump push below, so
+          # that push satisfies the branch-protection ruleset's repo-admin
+          # bypass (github-actions[bot] is not a bypass actor). See SK-2986.
+          token: ${{ secrets.PAT_ACTIONS }}
 
       - name: Set up maven or jfrog repository
         uses: actions/setup-java@v4


### PR DESCRIPTION
## Why
Branch protection rulesets now enforce **PR + 1 approval** and the **`Test`** status check on `main`/`v1`/`v3`. The automated release flow (`shared-build-and-deploy.yml`) pushes the version-bump commit **directly** to the release branch as `github-actions[bot]`, which is **not** a ruleset bypass actor — so that push would be rejected and releases would break.

## What
Point the release `actions/checkout` at `PAT_ACTIONS` (the **skyflow-service-it** admin service account). `checkout` persists this credential, and the later `git push origin <branch>` reuses it — so the push is attributed to a repo admin and satisfies the ruleset's **Repository Admin** bypass.

No ruleset changes required; the bypass is already configured.

## ⚠️ Verify before merge
This works only if `PAT_ACTIONS` is owned by **skyflow-service-it** (or another repo-admin) **and** has **Contents: write**. It is currently used only for the read-only commit-message checker. If it lacks push scope, swap `token:` for a write-capable PAT/App identity that is a bypass actor.

## Note
This PR is itself the first exercise of the new protection — it requires the `Test` check to pass and 1 approval before merge.

Ref: SK-2986 · [SDK Branch Protection — Gap Analysis](https://skyflow.atlassian.net/wiki/spaces/SDK1/pages/3027566593/SDK+Branch+Protection+Gap+Analysis)

🤖 Generated with [Claude Code](https://claude.com/claude-code)