### PR TITLE
SK-2986 use admin service-account PAT for release version-bump push (v3)

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -57,6 +57,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          # PAT of the skyflow-service-it admin service account. Persisted by
+          # checkout and reused for the automated version-bump push below, so
+          # that push satisfies the branch-protection ruleset's repo-admin
+          # bypass (github-actions[bot] is not a bypass actor). See SK-2986.
+          token: ${{ secrets.PAT_ACTIONS }}
 
       - name: Set up maven or jfrog repository
         uses: actions/setup-java@v1


### PR DESCRIPTION
Same fix as #371, applied to the **v3** branch's copy of `shared-build-and-deploy.yml`.

## Why
Branch protection now enforces PR + approval + the `Test` check on `main`/`v1`/`v3`. Beta/public releases resolve the tag's branch and push the version-bump commit directly to it as `github-actions[bot]`, which is not a ruleset bypass actor — so the push would be rejected.

## What
Release `actions/checkout` now uses `PAT_ACTIONS` (skyflow-service-it, a repo admin). The persisted credential is reused for the bump push, satisfying the ruleset's Repository Admin bypass.

## ⚠️ Verify before merge
Requires `PAT_ACTIONS` to be owned by a repo-admin account with **Contents: write**. See #371 for details.

Ref: SK-2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)