### PR TITLE
SK-2986 use admin service-account PAT for release version-bump push (v1)

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -48,6 +48,11 @@ jobs:
         with:
           ref: ${{ inputs.ref }}
           fetch-depth: 0
+          # PAT of the skyflow-service-it admin service account. Persisted by
+          # checkout and reused for the automated version-bump push below, so
+          # that push satisfies the branch-protection ruleset's repo-admin
+          # bypass (github-actions[bot] is not a bypass actor). See SK-2986.
+          token: ${{ secrets.PAT_ACTIONS }}
 
       - name: Set up maven or jfrog repository
         uses: actions/setup-java@v4


### PR DESCRIPTION
Third of three, matching #371 (main) and #372 (v3). Applies the fix to the **v1** branch's copy of `shared-build-and-deploy.yml`.

## Why
Branch protection now enforces PR + approval + the `Test` check on `main`/`v1`/`v3`. The v1 release pipeline (`release-v1.yml` → shared workflow) pushes the version-bump commit **directly to the protected `v1` branch** (`git push origin HEAD:v1`) as `github-actions[bot]`, which is not a ruleset bypass actor — so the push would be rejected and v1 releases would break.

## What
Point the release `actions/checkout` at `PAT_ACTIONS` (skyflow-service-it, a repo admin). The persisted credential is reused for the bump push, satisfying the ruleset's Repository Admin bypass.

## ⚠️ Verify before merge
Requires `PAT_ACTIONS` to be owned by a repo-admin account with **Contents: write**. It is currently used only for the read-only commit-message checker — confirm its scope, or switch to a purpose-built write-capable token. See #371 for the full discussion (incl. the alternative of dropping the version-bump push entirely).

Ref: SK-2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)