### PR TITLE
SK-2986 fix v3 release: pass PAT_ACTIONS into reusable workflow

### DIFF
--- a/.github/workflows/beta-release.yml
+++ b/.github/workflows/beta-release.yml
@@ -19,3 +19,4 @@ jobs:
       skyflow-credentials: ${{ secrets.SKYFLOW_CREDENTIALS }} >> .env
       test-expired-token: ${{ secrets.TEST_EXPIRED_TOKEN }} >> .env
       test-reusable-token: ${{ secrets.TEST_REUSABLE_TOKEN }} >> .env
+      pat-actions: ${{ secrets.PAT_ACTIONS }}

--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -25,3 +25,4 @@ jobs:
       skyflow-credentials: ${{ secrets.SKYFLOW_CREDENTIALS }} >> .env
       test-expired-token: ${{ secrets.TEST_EXPIRED_TOKEN }} >> .env
       test-reusable-token: ${{ secrets.TEST_REUSABLE_TOKEN }} >> .env
+      pat-actions: ${{ secrets.PAT_ACTIONS }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -18,3 +18,4 @@ jobs:
       skyflow-credentials: ${{ secrets.SKYFLOW_CREDENTIALS }} >> .env
       test-expired-token: ${{ secrets.TEST_EXPIRED_TOKEN }} >> .env
       test-reusable-token: ${{ secrets.TEST_REUSABLE_TOKEN }} >> .env
+      pat-actions: ${{ secrets.PAT_ACTIONS }}

--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -50,6 +50,9 @@ on:
       test-reusable-token:
         required: true
 
+      pat-actions:
+        required: true
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -61,7 +64,9 @@ jobs:
           # checkout and reused for the automated version-bump push below, so
           # that push satisfies the branch-protection ruleset's repo-admin
           # bypass (github-actions[bot] is not a bypass actor). See SK-2986.
-          token: ${{ secrets.PAT_ACTIONS }}
+          # Passed through workflow_call.secrets since reusable workflows do
+          # not inherit the caller's secrets automatically.
+          token: ${{ secrets.pat-actions }}
 
       - name: Set up maven or jfrog repository
         uses: actions/setup-java@v1


### PR DESCRIPTION
## Problem

The `build-and-deploy-v3 / publish` job fails at the very first step (`actions/checkout@v2`) with:

```
Error: Input required and not supplied: token
```

The checkout step supplies `token: ${{ secrets.PAT_ACTIONS }}` (added in #372 / SK-2986 so the persisted admin PAT can push the automated version bump past branch protection). But that step lives inside the **reusable** workflow `shared-build-and-deploy.yml` (`workflow_call`). Reusable workflows **do not inherit the caller's secrets** — a secret is only visible if it is declared in `workflow_call.secrets` and passed by the caller. `PAT_ACTIONS` was neither declared nor passed, so it resolved to empty and checkout hard-failed.

## Fix

Matches the repo's existing secret-passing pattern:

- `shared-build-and-deploy.yml`: declare a `pat-actions` `workflow_call` secret; checkout now uses `token: ${{ secrets.pat-actions }}`.
- Pass `pat-actions: ${{ secrets.PAT_ACTIONS }}` from all three callers: `internal-release.yml`, `release.yml`, `beta-release.yml`.

All four workflow files validated as YAML.

## Note (out of scope)

`shared-build-and-deploy.yml` also references `${{ secrets.TEST_CREDENTIALS_FILE_STRING }}` directly (create-json step) without declaring/passing it, so `credentials.json` is built empty. The job currently dies at checkout before reaching it. Left for a separate change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)