### PR TITLE
Fix internal-release infinite loop ([skip ci] on version-bump commit)

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -118,7 +118,10 @@ jobs:
 
           git add v3/pom.xml
           if [[ "${{ inputs.tag }}" == "internal" ]]; then
-            git commit -m "[AUTOMATED] Private Release ${{ steps.previoustag.outputs.tag }}-dev-$(git rev-parse --short $GITHUB_SHA)"
+            # [skip ci]: the version-bump push uses a PAT (see checkout above), and PAT-authored
+            # pushes DO trigger workflows (unlike GITHUB_TOKEN). Without this marker the push
+            # re-triggers this same internal-release workflow -> bump -> push -> infinite loop.
+            git commit -m "[AUTOMATED] Private Release ${{ steps.previoustag.outputs.tag }}-dev-$(git rev-parse --short $GITHUB_SHA) [skip ci]"
             git push origin ${{ github.ref_name }} -f
           fi
           if [[ "${{ inputs.tag }}" == "beta" || "${{ inputs.tag }}" == "public" ]]; then


### PR DESCRIPTION
## Problem

`internal-release.yml` triggers on **push** to `v3-release/*`. The reusable `shared-build-and-deploy.yml` bumps `v3/pom.xml`, commits `[AUTOMATED] Private Release …-dev-<sha>`, and **force-pushes to the same branch**.

Since **SK-2986 (#372)** that push authenticates with an **admin PAT** (to satisfy the branch-protection bypass). GitHub does **not** trigger workflows for pushes made with the default `GITHUB_TOKEN`, but **does** for PAT-authored pushes. So every automated bump re-triggered the workflow → bump → push → **infinite loop** (a new dev release every ~15–20s on `v3-release/26.7.29`).

## Fix

Append `[skip ci]` to the automated internal-release commit message so the bump push no longer re-triggers CI. The PAT stays (so #372's branch-protection fix is preserved); only the loop is broken.

## Notes

- The workflow was **disabled manually** to stop the active loop. After this merges, re-enable it with `gh workflow enable internal-release.yml`.
- Scope: only the `internal` path (the confirmed loop). Beta/public paths are tag/release-triggered, not branch-push, so they don't loop the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)