### PR TITLE
Fix internal-release infinite loop on main ([skip ci] on version-bump commit)

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -106,7 +106,10 @@ jobs:
 
           git add pom.xml
           if [[ "${{ inputs.tag }}" == "internal" ]]; then
-            git commit -m "[AUTOMATED] Private Release ${{ steps.previoustag.outputs.tag }}-dev-$(git rev-parse --short $GITHUB_SHA)"
+            # [skip ci]: the version-bump push uses a PAT (see checkout above), and PAT-authored
+            # pushes DO trigger workflows (unlike GITHUB_TOKEN). Without this marker the push
+            # re-triggers this same internal-release workflow -> bump -> push -> infinite loop.
+            git commit -m "[AUTOMATED] Private Release ${{ steps.previoustag.outputs.tag }}-dev-$(git rev-parse --short $GITHUB_SHA) [skip ci]"
             git push origin ${{ github.ref_name }} -f
           fi
           if [[ "${{ inputs.tag }}" == "beta" || "${{ inputs.tag }}" == "public" ]]; then


### PR DESCRIPTION
## Problem

The `internal` release path in `shared-build-and-deploy.yml` bumps the version and **force-pushes** an automated `[AUTOMATED] Private Release …-dev-<sha>` commit back to the branch using an **admin PAT**. GitHub does **not** trigger workflows for `GITHUB_TOKEN` pushes, but **does** for PAT-authored pushes — so each bump re-triggers the internal-release workflow → bump → push → **infinite loop**.

This is the same defect fixed on `v3-release/26.7.29` in #377. Putting it on `main` ensures future release branches cut from `main` don't reintroduce the loop.

## Fix

Append `[skip ci]` to the automated internal-release commit message so the bump push no longer re-triggers CI. The PAT stays (branch-protection bypass preserved); only the loop is broken.

## Scope

Only the `internal` path (the confirmed loop). Beta/public paths are tag/release-triggered, not branch-push, so they don't loop the same way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)