### PR TITLE
Switch main internal-release to the automated-bump guard (fixes #378 leftover)

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -10,6 +10,10 @@ on:
 
 jobs:
   build-and-deploy:
+    # Skip the automated version-bump commit so it can't re-trigger this workflow.
+    # The bump is pushed with a PAT (which, unlike GITHUB_TOKEN, DOES trigger workflows),
+    # so without this guard the release loops: bump -> push -> release -> bump -> ...
+    if: ${{ !contains(github.event.head_commit.message, '[AUTOMATED]') }}
     uses: ./.github/workflows/shared-build-and-deploy.yml
     with:
       ref: ${{ github.ref_name }}

--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -106,10 +106,11 @@ jobs:
 
           git add pom.xml
           if [[ "${{ inputs.tag }}" == "internal" ]]; then
-            # [skip ci]: the version-bump push uses a PAT (see checkout above), and PAT-authored
-            # pushes DO trigger workflows (unlike GITHUB_TOKEN). Without this marker the push
-            # re-triggers this same internal-release workflow -> bump -> push -> infinite loop.
-            git commit -m "[AUTOMATED] Private Release ${{ steps.previoustag.outputs.tag }}-dev-$(git rev-parse --short $GITHUB_SHA) [skip ci]"
+            # The '[AUTOMATED]' marker is what stops the release loop: internal-release.yml
+            # skips any push whose head commit contains it (the bump is pushed with a PAT,
+            # which — unlike GITHUB_TOKEN — DOES trigger workflows). Keep the marker in sync
+            # with that guard. This keeps PR CI intact (no global skip).
+            git commit -m "[AUTOMATED] Private Release ${{ steps.previoustag.outputs.tag }}-dev-$(git rev-parse --short $GITHUB_SHA)"
             git push origin ${{ github.ref_name }} -f
           fi
           if [[ "${{ inputs.tag }}" == "beta" || "${{ inputs.tag }}" == "public" ]]; then


### PR DESCRIPTION
#378 merged **before** it was converted from the skip-ci workaround to the scoped guard, so `main` is still on the bandage and inconsistent with the v3 line (which now uses the guard). This corrects `main`.

## Change
- `internal-release.yml`: add `if: ${{ !contains(github.event.head_commit.message, '[AUTOMATED]') }}` to the `build-and-deploy` job — the automated version-bump commit can no longer re-trigger the release (the loop), while PR CI and all other workflows still run.
- `shared-build-and-deploy.yml`: drop the skip-ci suffix from the bump commit message (the guard replaces it).

## Why the guard, not skip-ci
`skip ci` is global — it suppresses **every** workflow on the commit, including PR checks (that's the bug we hit on the release PR). The identity/marker guard is scoped to internal-release only.

Validated live on the v3 line: real commit → release ran; the automated bump it pushed was **skipped** (no loop), and PR CI ran normally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)