### PR TITLE
SK-3037 report the real cause when tokenize or delete never reach the API

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -108,7 +108,9 @@
     "deserialised",
     "unmodelled",
     "recordss",
-    "rarr"
+    "rarr",
+    "servname",
+    "nodename"
   ],
   "languageSettings": [
     {

--- a/flowvault/src/main/java/com/skyflow/utils/Utils.java
+++ b/flowvault/src/main/java/com/skyflow/utils/Utils.java
@@ -541,6 +541,32 @@ public final class Utils extends BaseUtils {
         return allRecords;
     }
 
+    /**
+     * Best available description of a failure that never reached the API.
+     *
+     * <p>The generated client wraps transport failures as "Network error executing HTTP request",
+     * which says nothing about what actually went wrong, and the future wraps that again. Walk down
+     * to the innermost cause so the caller sees the real problem - for a mistyped cluster id that is
+     * {@code java.net.UnknownHostException: <host>: nodename nor servname provided, or not known}
+     * rather than the generic wrapper. Mirrors the order bulk insert and detokenize already use.
+     */
+    private static String describeTransportFailure(Throwable ex, Throwable cause) {
+        String message = null;
+        if (cause != null && cause.getMessage() != null) {
+            message = cause.getMessage();
+        }
+        if (cause != null && cause.getLocalizedMessage() != null) {
+            message = cause.getLocalizedMessage();
+        }
+        if (cause != null && cause.getCause() != null) {
+            message = cause.getCause().toString();
+        }
+        if (message == null || message.trim().isEmpty()) {
+            message = ex.getMessage();
+        }
+        return message;
+    }
+
     public static List<BulkDeleteTokensResponseRecord> handleBulkDeleteTokensBatchException(
             Throwable ex,
             com.skyflow.generated.rest.resources.flowservice.requests.V1FlowDeleteTokenRequest batch,
@@ -595,9 +621,10 @@ public final class Utils extends BaseUtils {
             }
         } else {
             // a transport-level failure never reached the API, so there is no id to report
+            String message = describeTransportFailure(ex, cause);
             for (int position = 0; position < batchTokens.size(); position++) {
                 errorRecords.add(new BulkDeleteTokensResponseRecord(
-                        startIndex + position, tokenAt(batchTokens, position), 500, ex.getMessage()));
+                        startIndex + position, tokenAt(batchTokens, position), 500, message));
             }
         }
         return errorRecords;
@@ -645,7 +672,7 @@ public final class Utils extends BaseUtils {
         } else {
             // a transport-level failure never reached the API, so there is no id to report
             httpCode = 500;
-            message = ex.getMessage();
+            message = describeTransportFailure(ex, cause);
         }
         // a batch-level failure fails every token group of every value in that batch
         List<BulkTokenizeResponseRecord> errorRecords = new ArrayList<>();
@@ -717,10 +744,6 @@ public final class Utils extends BaseUtils {
             }
         }
         return apiException.getMessage();
-    }
-
-    private static BulkTokenizeRequestRecord recordAt(List<BulkTokenizeRequestRecord> records, int position) {
-        return (records != null && position < records.size()) ? records.get(position) : null;
     }
 
     public static BulkInsertResponse formatBulkInsertResponse(V1InsertResponse response, int batch, int batchSize, Map<String, List<String>> headers) {

--- a/flowvault/src/test/java/com/skyflow/utils/RequestIdTests.java
+++ b/flowvault/src/test/java/com/skyflow/utils/RequestIdTests.java
@@ -216,6 +216,45 @@ public class RequestIdTests {
     }
 
     @Test
+    public void testTokenize_transportFailureReportsTheInnermostCause() {
+        // a mistyped cluster id surfaces as UnknownHostException three levels down: the future
+        // wraps ApiClientException("Network error..."), which wraps the real cause. Reporting the
+        // wrapper tells the caller nothing, so the innermost cause must win.
+        java.net.UnknownHostException dns = new java.net.UnknownHostException(
+                "badcluster.skyvault.skyflowapis.dev: nodename nor servname provided, or not known");
+        Throwable ex = new RuntimeException(
+                new com.skyflow.generated.rest.core.ApiClientException(
+                        "Network error executing HTTP request", dns));
+
+        List<BulkTokenizeResponseRecord> records = Utils.handleBulkTokenizeBatchException(
+                ex, Collections.singletonList(tokenizeRecord("v0", "g1")), 0);
+
+        String error = records.get(0).getTokens().get(0).getError();
+        Assert.assertTrue("expected the DNS failure, got: " + error,
+                error.contains("UnknownHostException"));
+        Assert.assertTrue(error.contains("badcluster.skyvault.skyflowapis.dev"));
+    }
+
+    @Test
+    public void testDelete_transportFailureReportsTheInnermostCause() {
+        java.net.UnknownHostException dns = new java.net.UnknownHostException(
+                "badcluster.skyvault.skyflowapis.dev: nodename nor servname provided, or not known");
+        Throwable ex = new RuntimeException(
+                new com.skyflow.generated.rest.core.ApiClientException(
+                        "Network error executing HTTP request", dns));
+
+        List<BulkDeleteTokensResponseRecord> records =
+                Utils.handleBulkDeleteTokensBatchException(ex, deleteBatch("t0", "t1"), 0, 50);
+
+        Assert.assertEquals(2, records.size());
+        for (BulkDeleteTokensResponseRecord record : records) {
+            Assert.assertTrue("expected the DNS failure, got: " + record.getError(),
+                    record.getError().contains("UnknownHostException"));
+            Assert.assertEquals(Integer.valueOf(500), record.getHttpCode());
+        }
+    }
+
+    @Test
     public void testTokenize_transportFailureHasNoRequestId() {
         // never reached the API, so there is no call to point at
         List<BulkTokenizeResponseRecord> records = Utils.handleBulkTokenizeBatchException(


### PR DESCRIPTION
## The problem

A mistyped cluster id produced this on every record:

```json
{"httpCode":500,"error":"com.skyflow.generated.rest.core.ApiClientException: Network error executing HTTP request","requestId":null}
```

That names the wrapper, not the failure. Bulk **insert** already reported the useful form for the same mistake:

```
java.net.UnknownHostException: a370a96581411.skyvault.skyflowapis-preview.com: nodename nor servname provided, or not known
```

The difference was in the non-API branch of the batch-exception handlers. Insert walks down to the cause underneath; tokenize and delete stopped at `ex.getMessage()` and got the wrapper.

## The fix

Insert's chain, extracted as `describeTransportFailure` and called from both operations:

```java
cause.getMessage()
cause.getLocalizedMessage()
cause.getCause().toString()      // ← the step that reaches the real failure
ex.getMessage()                  // only if everything above is blank
```

Step 3 is what matters: the future wraps `ApiClientException("Network error executing HTTP request")`, which wraps the actual `UnknownHostException`.

Same order and same precedence as `handleBulkInsertBatchException`, so all three operations now describe a transport failure identically. Insert and detokenize keep their inline copies — this PR doesn't touch them.

## Scope

Only the **transport** branch changes. A request that reached the API still reports what the API said and still carries its request id; that path is untouched.

Also drops `recordAt`, which lost its last caller when `groupTokenizeRows` replaced the positional lookup.

## Testing

626 tests pass. Two new ones, one per operation, build the real three-level chain — `RuntimeException` → `ApiClientException("Network error…")` → `UnknownHostException` — and assert the surfaced error contains both the exception type and the host name, at HTTP 500.

Verified end to end against a DEV vault with a deliberately mistyped cluster id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)