### PR TITLE
SK-3037 add bulk tokenize and delete-tokens samples

### DIFF
--- a/flowvault/samples/src/main/java/com/example/vault/BulkDeleteTokensAsync.java
+++ b/flowvault/samples/src/main/java/com/example/vault/BulkDeleteTokensAsync.java
@@ -1,0 +1,93 @@
+package com.example.vault;
+
+import com.skyflow.Skyflow;
+import com.skyflow.config.Credentials;
+import com.skyflow.config.VaultConfig;
+import com.skyflow.enums.Env;
+import com.skyflow.enums.LogLevel;
+import com.skyflow.errors.SkyflowException;
+import com.skyflow.vault.data.BulkDeleteTokensRequest;
+import com.skyflow.vault.data.BulkDeleteTokensResponse;
+import com.skyflow.vault.data.BulkDeleteTokensResponseRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/**
+ * This sample demonstrates how to perform an asynchronous bulk delete tokens operation using the Skyflow Java SDK.
+ * The process involves:
+ * 1. Setting up credentials and vault configuration
+ * 2. Creating a list of tokens to delete
+ * 3. Building and executing an async bulk delete tokens request
+ * 4. Reading the per-token outcome and the summary from the response
+ * 5. Handling the delete response or errors using CompletableFuture
+ */
+public class BulkDeleteTokensAsync {
+
+    public static void main(String[] args) {
+        try {
+            // Step 1: Initialize credentials using credentials string
+            String credentialsString = "<YOUR_CREDENTIALS_STRING>";
+            Credentials credentials = new Credentials();
+            credentials.setCredentialsString(credentialsString);
+
+            // Step 2: Configure the vault with required parameters
+            VaultConfig vaultConfig = new VaultConfig();
+            vaultConfig.setVaultId("<YOUR_VAULT_ID>");
+            vaultConfig.setClusterId("<YOUR_CLUSTER_ID>");
+            vaultConfig.setEnv(Env.PROD);
+            vaultConfig.setCredentials(credentials);
+
+            // Step 3: Create Skyflow client instance with error logging
+            Skyflow skyflowClient = Skyflow.builder()
+                    .setLogLevel(LogLevel.ERROR)
+                    .addVaultConfig(vaultConfig)
+                    .build();
+
+            // Step 4: Prepare list of tokens to delete. The SDK assigns each token an index from its
+            // position in this list and returns it on the matching response record, so results stay
+            // correlated even though the batches complete out of order.
+            List<String> tokens = new ArrayList<>();
+            tokens.add("<YOUR_TOKEN_1>");
+            tokens.add("<YOUR_TOKEN_2>");
+
+            // Step 5: Build the bulk delete tokens request
+            BulkDeleteTokensRequest deleteTokensRequest = BulkDeleteTokensRequest.builder()
+                    .tokens(tokens)
+                    .build();
+
+            // Step 6: Execute the async bulk delete tokens operation and handle response using callbacks
+            CompletableFuture<BulkDeleteTokensResponse> future =
+                    skyflowClient.vault().bulkDeleteTokensAsync(deleteTokensRequest);
+            future.thenAccept(response -> {
+                System.out.println("Async bulk delete tokens resolved with response:\t" + response);
+
+                // Successes and failures share one list: a record succeeded when its error is null.
+                // requestId identifies the API call an error came from and is set on failures only.
+                for (BulkDeleteTokensResponseRecord record : response.getRecords()) {
+                    if (record.getError() == null) {
+                        System.out.printf("[%d] %s deleted (%d)%n",
+                                record.getIndex(), record.getToken(), record.getHttpCode());
+                    } else {
+                        System.out.printf("[%d] %s failed (%d): %s [requestId=%s]%n",
+                                record.getIndex(), record.getToken(), record.getHttpCode(),
+                                record.getError(), record.getRequestId());
+                    }
+                }
+
+                // Tokens that failed with a retryable status (5xx other than 529) can be resubmitted
+                if (!response.getTokensToRetry().isEmpty()) {
+                    System.out.println("tokens to retry:\t" + response.getTokensToRetry());
+                }
+            }).exceptionally(throwable -> {
+                System.err.println("Async bulk delete tokens rejected with error:\t" + throwable.getMessage());
+                throw new CompletionException(throwable);
+            });
+        } catch (SkyflowException e) {
+            // Step 7: Handle any synchronous errors that occur during setup
+            System.err.println("Error in Skyflow operations: " + e.getMessage());
+        }
+    }
+}

--- a/flowvault/samples/src/main/java/com/example/vault/BulkDeleteTokensSync.java
+++ b/flowvault/samples/src/main/java/com/example/vault/BulkDeleteTokensSync.java
@@ -1,0 +1,99 @@
+package com.example.vault;
+
+import com.skyflow.Skyflow;
+import com.skyflow.config.Credentials;
+import com.skyflow.config.VaultConfig;
+import com.skyflow.enums.Env;
+import com.skyflow.enums.LogLevel;
+import com.skyflow.errors.SkyflowException;
+import com.skyflow.vault.data.BulkDeleteTokensRequest;
+import com.skyflow.vault.data.BulkDeleteTokensResponse;
+import com.skyflow.vault.data.BulkDeleteTokensResponseRecord;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This sample demonstrates how to perform a synchronous bulk delete tokens operation using the Skyflow Java SDK.
+ * The process involves:
+ * 1. Setting up credentials and vault configuration
+ * 2. Creating a list of tokens to delete
+ * 3. Building and executing a bulk delete tokens request
+ * 4. Reading the per-token outcome and the summary from the response
+ * 5. Handling the delete response or any potential errors
+ */
+public class BulkDeleteTokensSync {
+
+    public static void main(String[] args) {
+        try {
+            // Step 1: Initialize credentials using credentials string
+            String credentialsString = "<YOUR_CREDENTIALS_STRING>";
+            Credentials credentials = new Credentials();
+            credentials.setCredentialsString(credentialsString);
+
+            // Step 2: Configure the vault with required parameters
+            VaultConfig vaultConfig = new VaultConfig();
+            vaultConfig.setVaultId("<YOUR_VAULT_ID>");
+            vaultConfig.setClusterId("<YOUR_CLUSTER_ID>");
+            vaultConfig.setEnv(Env.PROD);
+            vaultConfig.setCredentials(credentials);
+
+            // Step 3: Create Skyflow client instance with error logging
+            Skyflow skyflowClient = Skyflow.builder()
+                    .setLogLevel(LogLevel.ERROR)
+                    .addVaultConfig(vaultConfig)
+                    .build();
+
+            // Step 4: Prepare list of tokens to delete. The SDK assigns each token an index from its
+            // position in this list and returns it on the matching response record, so results stay
+            // correlated even though large requests are split into batches that run concurrently.
+            List<String> tokens = new ArrayList<>();
+            tokens.add("<YOUR_TOKEN_1>");
+            tokens.add("<YOUR_TOKEN_2>");
+
+            // Step 5: Build the bulk delete tokens request
+            BulkDeleteTokensRequest deleteTokensRequest = BulkDeleteTokensRequest.builder()
+                    .tokens(tokens)
+                    .build();
+
+            // Step 6: Execute the bulk delete tokens operation and print the response
+            BulkDeleteTokensResponse deleteTokensResponse =
+                    skyflowClient.vault().bulkDeleteTokens(deleteTokensRequest);
+            System.out.println(deleteTokensResponse);
+
+            // Step 7: Read the summary. totalTokens counts the tokens you submitted, and the other
+            // two classify each one, so together they sum to that count.
+            System.out.println("total tokens:\t" + deleteTokensResponse.getSummary().getTotalTokens());
+            System.out.println("deleted:\t" + deleteTokensResponse.getSummary().getTotalDeleted());
+            System.out.println("failed:\t\t" + deleteTokensResponse.getSummary().getTotalFailed());
+
+            // Step 8: Walk the per-token outcomes. Successes and failures share one list: a record
+            // succeeded when its error is null, and its index is the token's position in the request
+            // you submitted. requestId identifies the API call an error came from and is set on
+            // failures only.
+            for (BulkDeleteTokensResponseRecord record : deleteTokensResponse.getRecords()) {
+                if (record.getError() == null) {
+                    System.out.printf("[%d] %s deleted (%d)%n",
+                            record.getIndex(), record.getToken(), record.getHttpCode());
+                } else {
+                    System.out.printf("[%d] %s failed (%d): %s [requestId=%s]%n",
+                            record.getIndex(), record.getToken(), record.getHttpCode(),
+                            record.getError(), record.getRequestId());
+                }
+            }
+
+            // Step 9: Optionally retry the tokens that failed with a retryable status (5xx other
+            // than 529). A token that simply does not exist fails with a 4xx, so it is not included.
+            List<String> tokensToRetry = deleteTokensResponse.getTokensToRetry();
+            if (!tokensToRetry.isEmpty()) {
+                System.out.println("retrying:\t" + tokensToRetry);
+                BulkDeleteTokensResponse retryResponse = skyflowClient.vault().bulkDeleteTokens(
+                        BulkDeleteTokensRequest.builder().tokens(tokensToRetry).build());
+                System.out.println("retry response:\t" + retryResponse);
+            }
+        } catch (SkyflowException e) {
+            // Step 10: Handle any errors that occur during the process
+            System.err.println("Error in Skyflow operations: " + e.getMessage());
+        }
+    }
+}

--- a/flowvault/samples/src/main/java/com/example/vault/BulkTokenizeAsync.java
+++ b/flowvault/samples/src/main/java/com/example/vault/BulkTokenizeAsync.java
@@ -1,0 +1,112 @@
+package com.example.vault;
+
+import com.skyflow.Skyflow;
+import com.skyflow.config.Credentials;
+import com.skyflow.config.VaultConfig;
+import com.skyflow.enums.Env;
+import com.skyflow.enums.LogLevel;
+import com.skyflow.errors.SkyflowException;
+import com.skyflow.vault.data.BulkTokenizeRequest;
+import com.skyflow.vault.data.BulkTokenizeRequestRecord;
+import com.skyflow.vault.data.BulkTokenizeResponse;
+import com.skyflow.vault.data.BulkTokenizeResponseRecord;
+import com.skyflow.vault.data.TokenizeResponseToken;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
+
+/**
+ * This sample demonstrates how to perform an asynchronous bulk tokenize operation using the Skyflow Java SDK.
+ * The process involves:
+ * 1. Setting up credentials and vault configuration
+ * 2. Creating a list of records, each with a value and one or more token group names
+ * 3. Building and executing an async bulk tokenize request
+ * 4. Reading the per-token-group outcome for each value
+ * 5. Handling the tokenize response or errors using CompletableFuture
+ */
+public class BulkTokenizeAsync {
+
+    public static void main(String[] args) {
+        try {
+            // Step 1: Initialize credentials using credentials string
+            String credentialsString = "<YOUR_CREDENTIALS_STRING>";
+            Credentials credentials = new Credentials();
+            credentials.setCredentialsString(credentialsString);
+
+            // Step 2: Configure the vault with required parameters
+            VaultConfig vaultConfig = new VaultConfig();
+            vaultConfig.setVaultId("<YOUR_VAULT_ID>");
+            vaultConfig.setClusterId("<YOUR_CLUSTER_ID>");
+            vaultConfig.setEnv(Env.PROD);
+            vaultConfig.setCredentials(credentials);
+
+            // Step 3: Create Skyflow client instance with error logging
+            Skyflow skyflowClient = Skyflow.builder()
+                    .setLogLevel(LogLevel.ERROR)
+                    .addVaultConfig(vaultConfig)
+                    .build();
+
+            // Step 4: Specify the token groups to tokenize each value against
+            List<String> tokenGroupNames = new ArrayList<>();
+            tokenGroupNames.add("<YOUR_TOKEN_GROUP_NAME_1>");
+            tokenGroupNames.add("<YOUR_TOKEN_GROUP_NAME_2>");
+
+            // Step 5: Prepare the records to tokenize. The SDK assigns each record an index from its
+            // position in this list and returns it on the matching response record, so results stay
+            // correlated even though the batches complete out of order.
+            List<BulkTokenizeRequestRecord> records = new ArrayList<>();
+            records.add(BulkTokenizeRequestRecord.builder()
+                    .value("<YOUR_VALUE_1>")
+                    .tokenGroupNames(tokenGroupNames)
+                    .build());
+            records.add(BulkTokenizeRequestRecord.builder()
+                    .value("<YOUR_VALUE_2>")
+                    // Optional: supply your own token instead of having one generated (BYOT).
+                    // A BYOT record must name exactly one token group.
+                    // .token("<YOUR_OWN_TOKEN>")
+                    .tokenGroupNames(tokenGroupNames)
+                    .build());
+
+            // Step 6: Build the bulk tokenize request
+            BulkTokenizeRequest tokenizeRequest = BulkTokenizeRequest.builder()
+                    .records(records)
+                    .build();
+
+            // Step 7: Execute the async bulk tokenize operation and handle response using callbacks
+            CompletableFuture<BulkTokenizeResponse> future =
+                    skyflowClient.vault().bulkTokenizeAsync(tokenizeRequest);
+            future.thenAccept(response -> {
+                System.out.println("Async bulk tokenize resolved with response:\t" + response);
+
+                // Each value reports one entry per token group, so a value can partially succeed.
+                // requestId identifies the API call an error came from and is set on failures only.
+                for (BulkTokenizeResponseRecord record : response.getRecords()) {
+                    for (TokenizeResponseToken token : record.getTokens()) {
+                        if (token.getError() == null) {
+                            System.out.printf("[%d] group '%s' -> %s%n",
+                                    record.getIndex(), token.getTokenGroupName(), token.getToken());
+                        } else {
+                            System.out.printf("[%d] group '%s' failed (%d): %s [requestId=%s]%n",
+                                    record.getIndex(), token.getTokenGroupName(),
+                                    token.getHttpCode(), token.getError(), token.getRequestId());
+                        }
+                    }
+                }
+
+                // Records that failed with a retryable status (5xx other than 529) come back
+                // unchanged and can be resubmitted as-is.
+                if (!response.getRecordsToRetry().isEmpty()) {
+                    System.out.println("records to retry:\t" + response.getRecordsToRetry().size());
+                }
+            }).exceptionally(throwable -> {
+                System.err.println("Async bulk tokenize rejected with error:\t" + throwable.getMessage());
+                throw new CompletionException(throwable);
+            });
+        } catch (SkyflowException e) {
+            // Step 8: Handle any synchronous errors that occur during setup
+            System.err.println("Error in Skyflow operations: " + e.getMessage());
+        }
+    }
+}

--- a/flowvault/samples/src/main/java/com/example/vault/BulkTokenizeSync.java
+++ b/flowvault/samples/src/main/java/com/example/vault/BulkTokenizeSync.java
@@ -1,0 +1,115 @@
+package com.example.vault;
+
+import com.skyflow.Skyflow;
+import com.skyflow.config.Credentials;
+import com.skyflow.config.VaultConfig;
+import com.skyflow.enums.Env;
+import com.skyflow.enums.LogLevel;
+import com.skyflow.errors.SkyflowException;
+import com.skyflow.vault.data.BulkTokenizeRequest;
+import com.skyflow.vault.data.BulkTokenizeRequestRecord;
+import com.skyflow.vault.data.BulkTokenizeResponse;
+import com.skyflow.vault.data.BulkTokenizeResponseRecord;
+import com.skyflow.vault.data.TokenizeResponseToken;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This sample demonstrates how to perform a synchronous bulk tokenize operation using the Skyflow Java SDK.
+ * The process involves:
+ * 1. Setting up credentials and vault configuration
+ * 2. Creating a list of records, each with a value and one or more token group names
+ * 3. Building and executing a bulk tokenize request
+ * 4. Reading the per-token-group outcome for each value
+ * 5. Handling the tokenize response or any potential errors
+ */
+public class BulkTokenizeSync {
+
+    public static void main(String[] args) {
+        try {
+            // Step 1: Initialize credentials using credentials string
+            String credentialsString = "<YOUR_CREDENTIALS_STRING>";
+            Credentials credentials = new Credentials();
+            credentials.setCredentialsString(credentialsString);
+
+            // Step 2: Configure the vault with required parameters
+            VaultConfig vaultConfig = new VaultConfig();
+            vaultConfig.setVaultId("<YOUR_VAULT_ID>");
+            vaultConfig.setClusterId("<YOUR_CLUSTER_ID>");
+            vaultConfig.setEnv(Env.PROD);
+            vaultConfig.setCredentials(credentials);
+
+            // Step 3: Create Skyflow client instance with error logging
+            Skyflow skyflowClient = Skyflow.builder()
+                    .setLogLevel(LogLevel.ERROR)
+                    .addVaultConfig(vaultConfig)
+                    .build();
+
+            // Step 4: Specify the token groups to tokenize each value against
+            List<String> tokenGroupNames = new ArrayList<>();
+            tokenGroupNames.add("<YOUR_TOKEN_GROUP_NAME_1>");
+            tokenGroupNames.add("<YOUR_TOKEN_GROUP_NAME_2>");
+
+            // Step 5: Prepare the records to tokenize. The SDK assigns each record an index from its
+            // position in this list and returns it on the matching response record, so results stay
+            // correlated even though large requests are split into batches that run concurrently.
+            List<BulkTokenizeRequestRecord> records = new ArrayList<>();
+            records.add(BulkTokenizeRequestRecord.builder()
+                    .value("<YOUR_VALUE_1>")
+                    .tokenGroupNames(tokenGroupNames)
+                    .build());
+            records.add(BulkTokenizeRequestRecord.builder()
+                    .value("<YOUR_VALUE_2>")
+                    // Optional: supply your own token instead of having one generated (BYOT).
+                    // A BYOT record must name exactly one token group.
+                    // .token("<YOUR_OWN_TOKEN>")
+                    .tokenGroupNames(tokenGroupNames)
+                    .build());
+
+            // Step 6: Build the bulk tokenize request
+            BulkTokenizeRequest tokenizeRequest = BulkTokenizeRequest.builder()
+                    .records(records)
+                    .build();
+
+            // Step 7: Execute the bulk tokenize operation and print the response
+            BulkTokenizeResponse tokenizeResponse = skyflowClient.vault().bulkTokenize(tokenizeRequest);
+            System.out.println(tokenizeResponse);
+
+            // Step 8: Read the summary. totalTokens counts the values you submitted; the other three
+            // classify each value by how its token groups fared, so together they sum to that count.
+            System.out.println("total values:\t" + tokenizeResponse.getSummary().getTotalTokens());
+            System.out.println("tokenized:\t" + tokenizeResponse.getSummary().getTotalTokenized());
+            System.out.println("partial:\t" + tokenizeResponse.getSummary().getTotalPartial());
+            System.out.println("failed:\t\t" + tokenizeResponse.getSummary().getTotalFailed());
+
+            // Step 9: Walk the results. Each value reports one entry per token group, so a value can
+            // partially succeed: some groups return a token while others return an error. requestId
+            // identifies the API call an error came from and is set on failures only.
+            for (BulkTokenizeResponseRecord record : tokenizeResponse.getRecords()) {
+                for (TokenizeResponseToken token : record.getTokens()) {
+                    if (token.getError() == null) {
+                        System.out.printf("[%d] group '%s' -> %s%n",
+                                record.getIndex(), token.getTokenGroupName(), token.getToken());
+                    } else {
+                        System.out.printf("[%d] group '%s' failed (%d): %s [requestId=%s]%n",
+                                record.getIndex(), token.getTokenGroupName(),
+                                token.getHttpCode(), token.getError(), token.getRequestId());
+                    }
+                }
+            }
+
+            // Step 10: Optionally retry the records that failed with a retryable status (5xx other
+            // than 529). Your original records come back unchanged and can be resubmitted as-is.
+            List<BulkTokenizeRequestRecord> recordsToRetry = tokenizeResponse.getRecordsToRetry();
+            if (!recordsToRetry.isEmpty()) {
+                BulkTokenizeResponse retryResponse = skyflowClient.vault().bulkTokenize(
+                        BulkTokenizeRequest.builder().records(recordsToRetry).build());
+                System.out.println("retry response:\t" + retryResponse);
+            }
+        } catch (SkyflowException e) {
+            // Step 11: Handle any errors that occur during the process
+            System.err.println("Error in Skyflow operations: " + e.getMessage());
+        }
+    }
+}


### PR DESCRIPTION
`flowvault/samples` covered insert and detokenize but not the other two bulk operations. This adds the missing four:

- `BulkTokenizeSync`
- `BulkTokenizeAsync`
- `BulkDeleteTokensSync`
- `BulkDeleteTokensAsync`

They follow the existing files exactly — credentials string, placeholder vault and cluster ids, `Env.PROD`, numbered `Step N:` comments, and the same `thenAccept` / `exceptionally` shape on the async pair.

## What they show beyond printing the response

Each one covers what is specific to these two operations:

- **`index`** correlates a result with the record you submitted. This matters because large requests are split into batches that complete out of order, yet the records still come back aligned with your list.
- **`requestId`** names the API call an error came from, and is set on **failures only** — successes carry `null`, since there is nothing to look up.
- **`getRecordsToRetry()` / `getTokensToRetry()`** return what failed with a retryable status, ready to resubmit as-is. A missing token or an invalid token group is a 4xx, so neither is included — the samples say so rather than leaving an empty list unexplained.
- **Tokenize reports one entry per token group**, so a single value can partially succeed: some groups return a token while others return an error. The summary's `tokenized` / `partial` / `failed` classify each *value*, so they sum to `totalTokens`.
- **BYOT** appears as a commented-out `.token(...)` line, with the one-group-per-BYOT-record rule noted.

## Scope

Only these four files. Two pre-existing issues in the module are left alone as unrelated:

- `samples/pom.xml` pins `3.0.0-beta.13-dev.0d4db0a`, which predates `BulkTokenizeRequestRecord`, `BulkDeleteTokensResponseRecord` and `TokenizeResponseToken`. That version needs bumping before the module builds as a whole.
- `BearerTokenExpiryExample.java` imports `com.skyflow.vault.tokens`, a v2 package that does not exist in flowvault, and accounts for all 26 compile errors in the module today.

Because of the first point I verified these four with `javac` directly against the current SDK jar rather than through the module build: **all four compile cleanly**. cspell reports no issues, and every credential is a `<YOUR_...>` placeholder — 26 of them, no real values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)