### PR TITLE
SK-3002 fix javadoc links blocking the flowvault public release

### DIFF
--- a/flowvault/src/main/java/com/skyflow/vault/data/BulkTokenizeRequestRecord.java
+++ b/flowvault/src/main/java/com/skyflow/vault/data/BulkTokenizeRequestRecord.java
@@ -6,7 +6,8 @@ import java.util.List;
  * A record in a bulk tokenize request.
  *
  * <p>Carries nothing beyond {@link TokenizeRequestRecord} today. It exists as its own type so the
- * bulk request has somewhere to grow, mirroring the {@link BulkInsertRecord} / {@link InsertRecord}
+ * bulk request has somewhere to grow, mirroring the {@link BulkInsertRequestRecord} /
+ * {@link InsertRequestRecord}
  * split. The index that correlates a record with its result is assigned by the SDK from list
  * position and appears only on {@link BulkTokenizeResponseRecord} — callers never supply it.
  */


### PR DESCRIPTION
## Problem

`flowvault/v1.0.0` — the first real public release — failed at `Publish package` ([run 30826092656](https://github.com/skyflowapi/skyflow-java/actions/runs/30826092656/job/91728035291)):

```
flowvault/src/main/java/com/skyflow/vault/data/BulkTokenizeRequestRecord.java:9: error: reference not found
 * bulk request has somewhere to grow, mirroring the {@link BulkInsertRecord} / {@link InsertRecord}
```

Neither type exists. The real names are `BulkInsertRequestRecord` and `InsertRequestRecord` — the doc comment dropped `Request` from both. JDK doclint treats an unresolvable `@link` as an **error** (not a warning), so `maven-javadoc-plugin:jar (attach-javadocs)` exited 1.

`javadoc:jar` binds to `package`, which runs before `deploy`, so **nothing was published** — the upload never happened and nothing reached the Central Portal. No immutable state to clean up.

## Why it was invisible until now

Internal releases publish with `-Dmaven.javadoc.skip=true`, so javadoc is never built on that path. Public releases must **not** skip it, because Sonatype rejects a bundle with no `-javadoc.jar`. So a broken doc link can only surface on a real public release — which is exactly what happened.

The earlier `flowvault/v0.0.x` rehearsals did run `javadoc:jar`, but were cut before this class existed.

## Fix

One line — correct the two class names. No functional change; comment only.

## Verification

```
mvn --batch-mode -pl flowvault -am -DskipTests javadoc:jar
```

- **Before:** `BUILD FAILURE`, the same two `error: reference not found` as CI
- **After:** `BUILD SUCCESS` — javadoc jar builds for `skyflow`, `common` and `skyflow-flowvault-java`

Verified on JDK 17 (no JDK 11 available locally; the release runs 11). The `reference not found` doclint check is identical across both, but a JDK 11 confirmation from CI is worth having.

## Re-releasing after merge

Re-running the failed job alone won't work — it checks out the same `flowvault/v1.0.0` tag and rebuilds the same broken source. The tag needs to move to the fixed commit, or a new tag + Release cut.

The bump side is already safe: `4534e58 [AUTOMATED] Public Release - 1.0.0` is on `main` with `flowvault/pom.xml` at `1.0.0`, so on retry the `Commit changes` step takes the `pom already at the target version - nothing to commit` path and exits 0.

## Follow-ups (not in this PR)

1. **No PR check builds javadoc**, so this whole class of break is only ever caught mid-release. Adding `mvn -pl <module> -am javadoc:jar` to `pr.yml`/`pr-flowvault.yml` would move it left.
2. The same release log shows `warning: no @param` / `no @return` on the new `Skyflow.builder()` timeout/retry methods (`timeout`, `connectTimeout`, `readTimeout`, `writeTimeout`, `maxRetries`). Warnings only — they did not fail the build — but worth documenting since they are new public API.

🤖 Generated with [Claude Code](https://claude.com/claude-code)