### PR TITLE
SK-3002 stop publishing build-internal jars to Maven Central

### DIFF
--- a/flowvault/pom.xml
+++ b/flowvault/pom.xml
@@ -78,12 +78,17 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- Comparison-only jar (classifier "with-common") merging com.skyflow:common,
-                     mirroring skyvault. The published artifact is untouched: shadedArtifactAttached
-                     keeps the main jar as it was. This exists so japicmp compares the whole surface
-                     a consumer actually gets, since classes a customer imports (Credentials,
-                     SkyflowException, BearerToken) live in common and would otherwise read as
-                     missing - japicmp only sees what is physically inside the jars it is given. -->
+                <!-- Comparison-only jar merging com.skyflow:common, mirroring skyvault. This
+                     exists so japicmp compares the whole surface a consumer actually gets, since
+                     classes a customer imports (Credentials, SkyflowException, BearerToken) live
+                     in common and would otherwise read as missing - japicmp only sees what is
+                     physically inside the jars it is given.
+                     Written with outputFile, NOT shadedArtifactAttached: attaching it made it a
+                     secondary artifact, and every attached artifact is deployed, so this
+                     build-internal jar was being published to Maven Central as a permanent
+                     -with-common classifier. outputFile writes the jar and neither replaces the
+                     main artifact nor attaches it. The path is unchanged, so the japicmp
+                     newVersion path below still resolves. -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
@@ -95,8 +100,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>with-common</shadedClassifierName>
+                            <outputFile>${project.build.directory}/${project.build.finalName}-with-common.jar</outputFile>
                             <artifactSet>
                                 <includes>
                                     <include>com.skyflow:common</include>

--- a/pom.xml
+++ b/pom.xml
@@ -232,15 +232,12 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
                 <version>3.3.0</version>
-                <executions>
-                    <execution>
-                        <goals>
-                            <goal>test-jar</goal>
-                        </goals>
-                    </execution>
-                </executions>
-                <configuration>
-                </configuration>
+                <!-- No test-jar execution. The 'test-jar' goal ATTACHES the jar as a secondary
+                     artifact, and every attached artifact gets deployed - so it was being
+                     published to Maven Central as a permanent -tests.jar classifier alongside
+                     the SDK. Nothing in this repo depends on a test-jar (no <type>test-jar</type>
+                     dependency anywhere), and the release build's own tests run in-module, so
+                     generating it served no purpose. -->
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/skyvault/pom.xml
+++ b/skyvault/pom.xml
@@ -60,16 +60,18 @@
                 </executions>
             </plugin>
             <plugin>
-                <!-- Produces an additional, comparison-only jar (classifier "with-common")
-                     that merges in com.skyflow:common, same pattern flowvault already uses.
-                     The real published skyflow-java-2.1.1.jar is untouched (shadedArtifactAttached
-                     keeps the main artifact slim) - this attached jar exists only so japicmp can
-                     compare an apples-to-apples "everything a v2 consumer actually gets" surface
+                <!-- Produces an additional, comparison-only jar that merges in
+                     com.skyflow:common, same pattern flowvault already uses. It exists only so
+                     japicmp can compare an apples-to-apples "everything a v2 consumer gets" surface
                      against the old 2.1.0 baseline, which was a single self-contained jar
                      (predating the common/v2 split). Without this, classes that moved into
                      common (Credentials, ErrorCode, BearerToken, Token, etc.) would show up as
                      false-positive "removed" classes, since japicmp only compares what's
-                     physically inside the two jars it's given. -->
+                     physically inside the two jars it's given.
+                     Written with outputFile rather than shadedArtifactAttached: attaching it made
+                     it a secondary artifact, and attached artifacts are deployed, so a jar
+                     documented here as comparison-only was being published. outputFile keeps it
+                     on disk without attaching. Path unchanged, so japicmp still resolves it. -->
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
                 <version>3.6.0</version>
@@ -81,8 +83,7 @@
                             <goal>shade</goal>
                         </goals>
                         <configuration>
-                            <shadedArtifactAttached>true</shadedArtifactAttached>
-                            <shadedClassifierName>with-common</shadedClassifierName>
+                            <outputFile>${project.build.directory}/${project.build.finalName}-with-common.jar</outputFile>
                             <artifactSet>
                                 <includes>
                                     <include>com.skyflow:common</include>


### PR DESCRIPTION
## Problem

The `flowvault/v1.0.0` bundle staged 11 files. Two of them are build-internal and were about to become **permanent public classifiers**:

```
skyflow-flowvault-java-1.0.0-tests.jar
skyflow-flowvault-java-1.0.0-with-common.jar
```

Both for the same reason: they are **attached** as secondary artifacts, and `deploy` uploads every attached artifact.

### `-with-common`

This is the japicmp comparison jar. `skyvault/pom.xml` already called it *"comparison-only"* — but `shadedArtifactAttached` is precisely what attaches it, so the documented intent was never actually enforced.

Replaced with shade's `<outputFile>`, which writes the jar and neither replaces the main artifact nor attaches it. The output path is deliberately unchanged, so the japicmp `newVersion` path needs no edit.

### `-tests`

From the root pom's `maven-jar-plugin` `test-jar` execution, inherited by every module. Nothing in the repo consumes a test-jar — there is no `<type>test-jar</type>` dependency anywhere — and the release build's tests run in-module, so the execution is removed.

## Correction: `excludeArtifacts` does not work for this

I suggested `excludeArtifacts` as the fix in #402. **That was wrong** and I want it on the record. Its filter compares against `Artifact.getArtifactId()`, not the classifier — from 0.11.0's `PublishMojo` bytecode:

```java
lambda$processRelease$1(ArtifactWithFile):
    getfield excludeArtifacts
    ArtifactWithFile.getArtifact().getArtifactId()   // ← artifactId, not classifier
    List.contains(...)
```

`-tests` and `-with-common` share the artifactId `skyflow-flowvault-java` with the main jar, so listing it would have dropped **the artifact you are publishing**. `excludeArtifacts` is for skipping a whole module in a multi-module build, not for pruning classifiers.

This PR therefore does **not** depend on #402 and is based directly on `main`.

## Verification

`mvn clean install` across the whole repo. Every module now attaches exactly jar + sources + javadoc:

```
Installing common/target/common-1.0.0.jar
Installing common/target/common-1.0.0-sources.jar
Installing common/target/common-1.0.0-javadoc.jar
--- japicmp-maven-plugin:0.26.0:cmp @ skyflow-java ---
Installing skyvault/target/skyflow-java-2.1.1.jar
Installing skyvault/target/skyflow-java-2.1.1-sources.jar
Installing skyvault/target/skyflow-java-2.1.1-javadoc.jar
--- japicmp-maven-plugin:0.26.0:cmp @ skyflow-flowvault-java ---
Installing flowvault/target/skyflow-flowvault-java-1.0.0.jar
Installing flowvault/target/skyflow-flowvault-java-1.0.0-sources.jar
Installing flowvault/target/skyflow-flowvault-java-1.0.0-javadoc.jar
BUILD SUCCESS
```

No `-tests`, no `-with-common` attached anywhere. `japicmp:cmp` still runs and passes for **both** modules, and `target/*-with-common.jar` is still produced on disk for it (confirmed on a clean build).

## Two observations, not changed here

**1. `-with-common` is redundant for flowvault.** Each module has a *second*, id-less shade execution that replaces the main artifact with a fat jar including `common`. So the main jar and the comparison jar are content-identical:

| jar | contains `common/Credentials.class` | classes |
|---|---|---|
| `skyflow-flowvault-java-1.0.0.jar` | yes | 353 |
| `skyflow-flowvault-java-1.0.0-with-common.jar` | yes | 353 |
| `original-skyflow-flowvault-java-1.0.0.jar` | no | 253 |

japicmp could point at the main jar and the extra shade execution could go entirely. Left alone as a behavioural change beyond this fix.

**2. Both module poms declare `maven-shade-plugin` twice**, which is the source of this warning on every build, already visible in the release logs:

```
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate
          declaration of plugin org.apache.maven.plugins:maven-shade-plugin
[WARNING] ... future Maven versions might no longer support building such malformed projects.
```

Merging them into one declaration with two executions would fix both this and (1).

## Timing

Worth merging **before** clicking Publish on the staged `1.0.0` deployment — otherwise those two classifiers are permanent. If the current deployment is already staged with them, it needs a Drop and a re-run rather than a Publish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)