### PR TITLE
SK-3002 replace stale v3 naming in the flowvault artifact metadata

### DIFF
--- a/flowvault/dependency-reduced-pom.xml
+++ b/flowvault/dependency-reduced-pom.xml
@@ -9,7 +9,7 @@
   <artifactId>skyflow-flowvault-java</artifactId>
   <name>${project.groupId}:${project.artifactId}</name>
   <version>1.0.0</version>
-  <description>Skyflow V3 SDK for the Java programming language</description>
+  <description>Skyflow FlowVault SDK for the Java programming language</description>
   <url>https://github.com/skyflowapi/skyflow-java/tree/main</url>
   <developers>
     <developer>

--- a/flowvault/pom.xml
+++ b/flowvault/pom.xml
@@ -14,7 +14,7 @@
     <version>1.0.0</version>
     <packaging>jar</packaging>
     <name>${project.groupId}:${project.artifactId}</name>
-    <description>Skyflow V3 SDK for the Java programming language</description>
+    <description>Skyflow FlowVault SDK for the Java programming language</description>
     <url>https://github.com/skyflowapi/skyflow-java/tree/main</url>
 
     <licenses>

--- a/flowvault/src/main/java/com/skyflow/utils/Constants.java
+++ b/flowvault/src/main/java/com/skyflow/utils/Constants.java
@@ -27,7 +27,7 @@ public final class Constants extends BaseConstants {
     public static final Integer TOKENIZE_CONCURRENCY_LIMIT = 1;
     public static final Integer MAX_TOKENIZE_BATCH_SIZE = 1000;
     public static final Integer MAX_TOKENIZE_CONCURRENCY_LIMIT = 10;
-    public static final String DEFAULT_SDK_VERSION = "v3";
+    public static final String DEFAULT_SDK_VERSION = "1.0.0";
     public static final String CONTEXT_KEY_REGEX = "^[a-zA-Z0-9_]+$";
 
     static {


### PR DESCRIPTION
## Problem

`v3` was the module's directory name before the package split. Two consumer-visible strings still carried it.

**1. The Maven Central description.** [`com.skyflow:skyflow-flowvault-java`](https://central.sonatype.com/artifact/com.skyflow/skyflow-flowvault-java) is described as *"Skyflow V3 SDK for the Java programming language"*:

```
$ curl -s https://repo1.maven.org/maven2/com/skyflow/skyflow-flowvault-java/1.0.0/skyflow-flowvault-java-1.0.0.pom | grep description
  <description>Skyflow V3 SDK for the Java programming language</description>
```

It means nothing to anyone browsing Central, and matches neither the module README heading (`Skyflow FlowVault Java SDK`) nor the parent POM's `Skyflow SDK for the Java programming language`.

**2. The telemetry fallback.** `DEFAULT_SDK_VERSION` is used when `sdk.properties` cannot be read, and feeds the `sdk_name_version` metric as `"skyflow-flowvault-java@" + version`. It was `"v3"`, so the fallback path reported a version the artifact never had — flowvault is versioned `1.0.0`, not `3.x`.

## Changes

```diff
 flowvault/pom.xml
-<description>Skyflow V3 SDK for the Java programming language</description>
+<description>Skyflow FlowVault SDK for the Java programming language</description>

 flowvault/src/main/java/com/skyflow/utils/Constants.java
-public static final String DEFAULT_SDK_VERSION = "v3";
+public static final String DEFAULT_SDK_VERSION = "1.0.0";
```

`1.0.0` makes the fallback report the same value the normal path already resolves from `sdk.properties`, so the two paths are indistinguishable in metrics.

## Verification

Editing `pom.xml` alone is sufficient for the deployed metadata. The POM Maven actually deploys is the shade plugin's `dependency-reduced-pom.xml` (which is why `com.skyflow:common` is absent from the published POM — it is shaded into the jar). It regenerates at `package` time, and the regenerated file is byte-identical to the POM on Central apart from this one line:

```
$ diff skyflow-flowvault-java-1.0.0.pom flowvault/dependency-reduced-pom.xml
12c12
<   <description>Skyflow V3 SDK for the Java programming language</description>
---
>   <description>Skyflow FlowVault SDK for the Java programming language</description>
```

Effective POM:

```
$ mvn -pl flowvault help:evaluate -Dexpression=project.description -DforceStdout
Skyflow FlowVault SDK for the Java programming language
```

flowvault suite:

```
$ mvn -pl flowvault test
Tests run: 674, Failures: 0, Errors: 0, Skipped: 0
BUILD SUCCESS
```

No test asserted on the old `"v3"` value. (`RequestIdTests` contains `"v2"`/`"v3"` string literals, but those are per-record payload *values* — `v0`…`v3` across four records — not module names.)

## Notes

- `1.0.0` is already on Central and deployed POMs are immutable, so the existing listing keeps the old description permanently. The fix is visible from the next release onward.
- `flowvault-release/26.8.1` carries both stale strings too; since merges flow `main` → `flowvault-release`, this should reach it on the next sync rather than needing a separate PR.
- Out of scope, noted while checking: `flowvault/dependency-reduced-pom.xml` is a generated build artifact but is tracked in git, so any local build dirties the tree. `skyvault/dependency-reduced-pom.xml` is untracked, so the two modules are inconsistent — worth gitignoring separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)