### PR TITLE
SK-2977 add beta build disclaimer banner to README on release

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -171,6 +171,7 @@ jobs:
           fi
 
           git add ${{ inputs.module }}/pom.xml
+          git add ${{ inputs.module }}/README.md
 
           # Nothing staged = pom already at this version (normal if set before
           # tagging). That is success; a bare 'git commit' would exit 1 here.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,8 @@ This repository hosts Skyflow's Java SDKs for integrating Skyflow into a Java ba
 
 > Migrating from v1? See skyvault's **[Migration Guide](docs/migrate_to_v2.md)**. V1 is in maintenance mode and will reach End of Life on October 31, 2026.
 
+> Using a beta version? `skyvault` and `flowvault` version independently — if the version you've installed contains `-beta.N`, see that package's own README for its beta disclaimer. Beta builds are not GA-ready.
+
 ## Repository layout
 
 The root `pom.xml` (`packaging=pom`) aggregates this Maven reactor:

--- a/scripts/bump_version.sh
+++ b/scripts/bump_version.sh
@@ -3,6 +3,7 @@ Version=$1
 CommitHash=$2
 Module=$3
 PomFile="$GITHUB_WORKSPACE/$Module/pom.xml"
+ReadmeFile="$GITHUB_WORKSPACE/$Module/README.md"
 
 if [ -z "$Version" ]; then
     echo "Error: Version argument is required."
@@ -22,6 +23,8 @@ if [ -z "$CommitHash" ]; then
         }
         { print }
     ' "$PomFile" > tempfile && cat tempfile > "$PomFile" && rm -f tempfile
+
+    "$GITHUB_WORKSPACE/scripts/toggle_beta_banner.sh" "$ReadmeFile" "$Version"
 
     echo "--------------------------"
     echo "Done. Main project version now at $Version"

--- a/scripts/toggle_beta_banner.sh
+++ b/scripts/toggle_beta_banner.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# Insert or remove the beta-release disclaimer banner in a README, based on
+# whether the given version string is a pre-release build.
+#
+# Usage: scripts/toggle_beta_banner.sh <readme-path> <version>
+#
+# Idempotent: safe to run repeatedly against the same file and version.
+set -euo pipefail
+
+readme_path="$1"
+version="$2"
+
+marker_start="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+marker_end="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
+banner_body="> ⚠️ **Beta release — not for production use.** This is a pre-release build provided for early testing and feedback. It has not completed Skyflow's General Availability (GA) validation, its API may change before the stable release, and it is not covered by production SLAs or support commitments. Do not deploy beta builds to production environments."
+
+is_prerelease() {
+    [[ "$1" =~ -beta\.[0-9]+ ]]
+}
+
+# Strip any existing banner first, so re-running is idempotent regardless of
+# whether one is already present.
+awk -v start="$marker_start" -v end="$marker_end" '
+    { lines[NR] = $0 }
+    END {
+        start_line = 0
+        end_line = 0
+        for (i = 1; i <= NR; i++) {
+            if (lines[i] == start) start_line = i
+            if (lines[i] == end) end_line = i
+        }
+        if (start_line == 0 || end_line == 0) {
+            del_from = -1
+            del_to = -1
+        } else {
+            del_from = start_line
+            del_to = end_line
+            if (del_from > 1 && lines[del_from - 1] == "") del_from--
+            if (del_to < NR && lines[del_to + 1] == "") del_to++
+        }
+        for (i = 1; i <= NR; i++) {
+            if (i >= del_from && i <= del_to) continue
+            print lines[i]
+        }
+    }
+' "$readme_path" > "${readme_path}.tmp"
+mv "${readme_path}.tmp" "$readme_path"
+
+if is_prerelease "$version"; then
+    awk -v start="$marker_start" -v body="$banner_body" -v end="$marker_end" '
+        NR == 1 {
+            print
+            print ""
+            print start
+            print body
+            print end
+            print ""
+            next
+        }
+        { print }
+    ' "$readme_path" > "${readme_path}.tmp"
+    mv "${readme_path}.tmp" "$readme_path"
+fi

--- a/scripts/toggle_beta_banner.test.sh
+++ b/scripts/toggle_beta_banner.test.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOGGLE="$SCRIPT_DIR/toggle_beta_banner.sh"
+FIXTURE="$(mktemp)"
+MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+
+fail() {
+    echo "FAIL: $1"
+    rm -f "$FIXTURE"
+    exit 1
+}
+
+cat > "$FIXTURE" <<'EOF'
+# Skyflow Java
+
+The Skyflow Java SDK intro text.
+EOF
+
+"$TOGGLE" "$FIXTURE" "2.2.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner not inserted for beta version"
+
+"$TOGGLE" "$FIXTURE" "2.2.0-beta.1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner duplicated on repeat run"
+
+"$TOGGLE" "$FIXTURE" "2.2.0"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 0 ] || fail "banner not removed for GA version"
+
+grep -qF "intro text." "$FIXTURE" || fail "original README content lost"
+
+rm -f "$FIXTURE"
+echo "PASS: toggle_beta_banner.sh"


### PR DESCRIPTION
## Summary
Adds a standard beta/pre-release disclaimer banner to the README, automatically toggled in and out by the existing release automation — part of the CUST-4287 RCA follow-up ([SK-2977](https://skyflow.atlassian.net/browse/SK-2977)).

`skyvault` and `flowvault` version independently, so the toggle is scoped per module:
- `scripts/toggle_beta_banner.sh` inserts the banner right after a README's title when the version being released is a `-beta.N` pre-release, and removes it on GA releases. Idempotent.
- Wired into `scripts/bump_version.sh` against `$Module/README.md` (public/beta path only), and `shared-build-and-deploy.yml` now stages `${{ inputs.module }}/README.md` alongside `pom.xml`. A `skyvault` release never touches `flowvault/README.md` and vice versa (verified in review).
- Root `README.md` — a navigation page, not itself a versioned artifact — gets a one-time static note pointing readers to the relevant module's own disclaimer.
- `scripts/toggle_beta_banner.test.sh` covers insertion, idempotency, GA removal, and content preservation.

This is one of 8 sibling PRs (android, iOS, js, node, python, react-js, react-native, java) rolling out the same disclaimer text and mechanism across the SDKs. skyflow-go is deferred to a follow-up (no release CI to hook into today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SK-2977]: https://skyflow.atlassian.net/browse/SK-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ