### PR TITLE
SK-3061: fix bulkInsert/bulkInsertAsync's inconsistent exception handling

### DIFF
--- a/flowvault/src/main/java/com/skyflow/vault/controller/VaultController.java
+++ b/flowvault/src/main/java/com/skyflow/vault/controller/VaultController.java
@@ -157,6 +157,12 @@ public final class VaultController extends VaultClient {
             String bodyString = gson.toJson(e.body());
             LogUtil.printErrorLog(ErrorLogs.INSERT_RECORDS_REJECTED.getLog());
             throw new SkyflowException(e.statusCode(), e, e.headers(), bodyString);
+        } catch (SkyflowException e) {
+            LogUtil.printErrorLog(ErrorLogs.INSERT_RECORDS_REJECTED.getLog());
+            throw e;
+        } catch (Exception e) {
+            LogUtil.printErrorLog(ErrorLogs.INSERT_RECORDS_REJECTED.getLog());
+            throw new SkyflowException(e.getMessage());
         }
     }
 

--- a/flowvault/src/main/java/com/skyflow/vault/controller/VaultController.java
+++ b/flowvault/src/main/java/com/skyflow/vault/controller/VaultController.java
@@ -769,9 +769,9 @@ public final class VaultController extends VaultClient {
     ) throws ExecutionException, InterruptedException, SkyflowException {
         LogUtil.printInfoLog(InfoLogs.PROCESSING_BATCHES.getLog());
         List<BulkInsertResponseRecord> records = new ArrayList<>();
-        List<CompletableFuture<BulkInsertResponse>> futures = this.insertBatchFutures(insertRequest, interceptor, cfg);
 
         try {
+            List<CompletableFuture<BulkInsertResponse>> futures = this.insertBatchFutures(insertRequest, interceptor, cfg);
             CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             try {
                 allFutures.join();

--- a/flowvault/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
+++ b/flowvault/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
@@ -210,6 +210,32 @@ public class VaultControllerTests {
     }
 
     @Test
+    public void testBulkInsert_unexpectedExceptionWrappedAsSkyflowException() throws Exception {
+        ApiClient mockApi = Mockito.mock(ApiClient.class);
+        VaultController controller = createControllerWithMock(mockApi);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "john");
+        ArrayList<InsertRequestRecord> records = new ArrayList<>();
+        records.add(BulkInsertRequestRecord.builder().tableName("table1").data(data).build());
+        BulkInsertRequest request = BulkInsertRequest.builder().records(records).build();
+
+        RequestInterceptor interceptor = ctx -> {
+            throw new IllegalStateException("sync interceptor blew up");
+        };
+        BulkInsertOptions options = BulkInsertOptions.builder().interceptor(interceptor).build();
+
+        try {
+            controller.bulkInsert(request, options);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals("sync interceptor blew up", e.getMessage());
+        } catch (IllegalStateException e) {
+            Assert.fail("Expected SkyflowException, got IllegalStateException");
+        }
+    }
+
+    @Test
     public void testBulkInsert_interceptorAddsCustomHeader() throws Exception {
         ApiClient mockApi = Mockito.mock(ApiClient.class);
         RawFlowserviceClient mockRaw = mockRawFlowservice(mockApi);

--- a/flowvault/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
+++ b/flowvault/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
@@ -179,6 +179,37 @@ public class VaultControllerTests {
     }
 
     @Test
+    public void testBulkInsertAsync_unexpectedExceptionWrappedAsSkyflowException() throws Exception {
+        // Regression test: bulkInsertAsync's synchronous setup (before the batch futures exist)
+        // must wrap any unexpected exception in SkyflowException, same as every other bulk async
+        // method - not just ApiClientApiException. A RequestInterceptor is invoked synchronously
+        // per batch inside insertBatchFutures, so a caller interceptor that throws is a realistic
+        // way to trigger this without reaching into internals.
+        ApiClient mockApi = Mockito.mock(ApiClient.class);
+        VaultController controller = createControllerWithMock(mockApi);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "john");
+        ArrayList<InsertRequestRecord> records = new ArrayList<>();
+        records.add(BulkInsertRequestRecord.builder().tableName("table1").data(data).build());
+        BulkInsertRequest request = BulkInsertRequest.builder().records(records).build();
+
+        RequestInterceptor interceptor = ctx -> {
+            throw new IllegalStateException("interceptor blew up");
+        };
+        BulkInsertOptions options = BulkInsertOptions.builder().interceptor(interceptor).build();
+
+        try {
+            controller.bulkInsertAsync(request, options);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals("interceptor blew up", e.getMessage());
+        } catch (IllegalStateException e) {
+            Assert.fail("Expected SkyflowException, got IllegalStateException");
+        }
+    }
+
+    @Test
     public void testBulkInsert_interceptorAddsCustomHeader() throws Exception {
         ApiClient mockApi = Mockito.mock(ApiClient.class);
         RawFlowserviceClient mockRaw = mockRawFlowservice(mockApi);


### PR DESCRIPTION
## Summary

Both `bulkInsert()` (sync) and `bulkInsertAsync()` leaked raw exceptions instead of wrapping them in `SkyflowException`, unlike every other bulk operation.

### `bulkInsertAsync` — missing catch blocks

Only caught `ApiClientApiException`. `bulkDetokenizeAsync`, `bulkDeleteTokensAsync`, and `bulkTokenizeAsync` all additionally catch:

```java
} catch (SkyflowException e) {
    LogUtil.printErrorLog(...);
    throw e;                                    // rethrow as-is, don't double-wrap
} catch (Exception e) {
    LogUtil.printErrorLog(...);
    throw new SkyflowException(e.getMessage());  // any other unexpected failure
}
```

A caller-supplied `RequestInterceptor` is invoked synchronously per batch inside `insertBatchFutures` (before any `CompletableFuture` exists), so an interceptor that throws is a real, reachable trigger. Fixed by adding the same two catch blocks.

### `bulkInsert` (sync) — same leak, different mechanism

`processBulkInsertSync` called `insertBatchFutures` *before* its own `try` started, so the same interceptor-throws scenario leaked past `bulkInsert()`'s catch list too — even after the async side was fixed. This isn't `insertBatchFutures` missing something its siblings have: all four `*BatchFutures` helpers (`insertBatchFutures`, `detokenizeBatchFutures`, `deleteTokensBatchFutures`, `tokenizeBatchFutures`) have zero catch blocks of their own, identically. The asymmetry was entirely in the caller — `processBulkDetokenizeSync`/`processBulkDeleteTokensSync`/`processBulkTokenizeSync` all invoke their batch-futures helper *inside* their own `try`, so it's already caught and wrapped one layer down; `processBulkInsertSync` didn't. Fixed by moving the call inside the `try`, matching the other three exactly.

## Testing

Two regression tests, one per method, using a throwing `RequestInterceptor` to trigger the leak. Both confirmed to fail without their respective fix (verified by reverting locally, rerunning, restoring) and pass with it.

- `mvn -pl common,flowvault -am test -Dtest='!TokenTests#testExpiredTokenForIsExpiredToken' -DfailIfNoTests=false` → **705 tests, 0 failures**.
- `mvn -pl common,flowvault -am verify -Dgpg.skip=true` (same exclusion) → **BUILD SUCCESS**. No `japicmp` impact — no signature changes on either fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)