### PR TITLE
SK-3061: add path to Token; fix stale samples pom.xml version

### DIFF
--- a/flowvault/README.md
+++ b/flowvault/README.md
@@ -496,6 +496,8 @@ for (BulkInsertResponseRecord record : insertResponse.getRecords()) {
 
 The parser (`Token.parseTokens()`) normalizes every shape the raw wire value is known to take — a list of `{token, tokenGroupName}` entries, a single such entry not wrapped in a list, or a bare token value with no group information — into a consistent `List<Token>`, rather than throwing on an unexpected one. `getTokens()` returns `null` when the record has no tokens (e.g. a failed record).
 
+For a structured column (e.g. an object or array value), each entry also carries `getPath()` — the location within that column's own value the token came from, such as `"street"` or `"phone_numbers[0].type"`. It's `null` for a flat column, where there's nothing to point into.
+
 Accessors: `insertResponse.getSummary()`, `insertResponse.getRecords()`, and on each record `getIndex()`, `getTableName()`, `getSkyflowId()`, `getTokens()`, `getData()`, `getHashedData()`, `getHttpCode()`, `getError()`, `getRequestId()`.
 
 > **Deprecation notice:** `getFields()` is deprecated in favor of `getTokens()` — it is kept only for backward compatibility and will be removed in a future release. Update call sites to `getTokens()`.

--- a/flowvault/samples/pom.xml
+++ b/flowvault/samples/pom.xml
@@ -18,7 +18,7 @@
         <dependency>
             <groupId>com.skyflow</groupId>
             <artifactId>skyflow-flowvault-java</artifactId>
-            <version>3.0.0-beta.13-dev.18f8f1ba</version>
+            <version>1.0.1</version>
         </dependency>
 
     </dependencies>

--- a/flowvault/src/main/java/com/skyflow/vault/controller/VaultController.java
+++ b/flowvault/src/main/java/com/skyflow/vault/controller/VaultController.java
@@ -769,9 +769,9 @@ public final class VaultController extends VaultClient {
     ) throws ExecutionException, InterruptedException, SkyflowException {
         LogUtil.printInfoLog(InfoLogs.PROCESSING_BATCHES.getLog());
         List<BulkInsertResponseRecord> records = new ArrayList<>();
+        List<CompletableFuture<BulkInsertResponse>> futures = this.insertBatchFutures(insertRequest, interceptor, cfg);
 
         try {
-            List<CompletableFuture<BulkInsertResponse>> futures = this.insertBatchFutures(insertRequest, interceptor, cfg);
             CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             try {
                 allFutures.join();

--- a/flowvault/src/main/java/com/skyflow/vault/data/Token.java
+++ b/flowvault/src/main/java/com/skyflow/vault/data/Token.java
@@ -12,17 +12,31 @@ import java.util.Map;
 /**
  * One token-group outcome for a single column value, as returned inside
  * {@link InsertResponseRecord#getTokens()}. A column tokenized against more than one
- * token group comes back as a list of these, one per group.
+ * token group comes back as a list of these, one per group. {@link #getPath()} identifies
+ * which part of a structured column value a token corresponds to, when applicable.
  */
 public class Token {
     @Expose(serialize = true)
     private final String token;
     @Expose(serialize = true)
     private final String tokenGroupName;
+    @Expose(serialize = true)
+    private final String path;
 
     public Token(String token, String tokenGroupName) {
+        this(token, tokenGroupName, null);
+    }
+
+    /**
+     * @param path the location, within the column's own (structured) value, that this token
+     *             corresponds to — e.g. {@code "street"} or {@code "phone_numbers[0].type"} for a
+     *             token generated from a nested field. {@code null} when the column's value isn't
+     *             structured, so there is nothing to point into.
+     */
+    public Token(String token, String tokenGroupName, String path) {
         this.token = token;
         this.tokenGroupName = tokenGroupName;
+        this.path = path;
     }
 
     public String getToken() {
@@ -31,6 +45,10 @@ public class Token {
 
     public String getTokenGroupName() {
         return tokenGroupName;
+    }
+
+    public String getPath() {
+        return path;
     }
 
     @Override
@@ -43,9 +61,11 @@ public class Token {
      * Parses the API's raw, generically-typed per-column token data (as returned by the wire
      * type, {@code Map<String, Object>}) into {@code Map<String, List<Token>>}. The API models
      * a column's tokens generically to stay flexible, so this parses every shape that generic
-     * value is known to take — a list of {@code {token, tokenGroupName}} entries (a column
+     * value is known to take — a list of {@code {token, tokenGroupName, path}} entries (a column
      * tokenized against more than one group), a single such entry, or a bare token value with
      * no group information — into a consistently-typed {@code List<Token>} per column.
+     * {@code path} is only present when the column's own value is itself structured (e.g. a
+     * nested object or array) and identifies which part of it a given token came from.
      *
      * <p>Returns {@code null} when {@code rawTokens} is {@code null} (e.g. a failed record). A
      * column whose raw value cannot be parsed into any of the above shapes is omitted, rather
@@ -91,8 +111,10 @@ public class Token {
             Map<?, ?> entryMap = (Map<?, ?>) entry;
             Object token = entryMap.get("token");
             Object tokenGroupName = entryMap.get("tokenGroupName");
+            Object path = entryMap.get("path");
             return new Token(token != null ? token.toString() : null,
-                    tokenGroupName != null ? tokenGroupName.toString() : null);
+                    tokenGroupName != null ? tokenGroupName.toString() : null,
+                    path != null ? path.toString() : null);
         }
         if (entry != null) {
             // A column tokenized against a single, unnamed group can come back as a bare value.
@@ -106,7 +128,8 @@ public class Token {
      * the generic {@code Map<String, Object>} shape {@code getFields()} returned before it was
      * deprecated, for callers who haven't migrated to {@link InsertResponseRecord#getTokens()}
      * yet. Each column's value becomes a {@code List<Map<String, Object>>}, one map per
-     * {@code Token} with {@code "token"}/{@code "tokenGroupName"} keys — this doesn't reproduce
+     * {@code Token} with {@code "token"}/{@code "tokenGroupName"} keys (plus {@code "path"} when
+     * present) — this doesn't reproduce
      * the exact original wire shape (a single-group column may originally have been a bare
      * value or an unwrapped map rather than a one-element list), since that distinction is lost
      * once parsed, but it's a consistent, self-describing shape every caller can read the same
@@ -125,6 +148,11 @@ public class Token {
                 Map<String, Object> rawEntry = new LinkedHashMap<>();
                 rawEntry.put("token", token.getToken());
                 rawEntry.put("tokenGroupName", token.getTokenGroupName());
+                // Only added when present, unlike token/tokenGroupName - so a path-less round trip
+                // (the common case) stays exactly as lossless as it was before path existed.
+                if (token.getPath() != null) {
+                    rawEntry.put("path", token.getPath());
+                }
                 rawEntries.add(rawEntry);
             }
             raw.put(entry.getKey(), rawEntries);

--- a/flowvault/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
+++ b/flowvault/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
@@ -210,32 +210,6 @@ public class VaultControllerTests {
     }
 
     @Test
-    public void testBulkInsert_unexpectedExceptionWrappedAsSkyflowException() throws Exception {
-        ApiClient mockApi = Mockito.mock(ApiClient.class);
-        VaultController controller = createControllerWithMock(mockApi);
-
-        Map<String, Object> data = new HashMap<>();
-        data.put("name", "john");
-        ArrayList<InsertRequestRecord> records = new ArrayList<>();
-        records.add(BulkInsertRequestRecord.builder().tableName("table1").data(data).build());
-        BulkInsertRequest request = BulkInsertRequest.builder().records(records).build();
-
-        RequestInterceptor interceptor = ctx -> {
-            throw new IllegalStateException("sync interceptor blew up");
-        };
-        BulkInsertOptions options = BulkInsertOptions.builder().interceptor(interceptor).build();
-
-        try {
-            controller.bulkInsert(request, options);
-            Assert.fail(EXCEPTION_NOT_THROWN);
-        } catch (SkyflowException e) {
-            Assert.assertEquals("sync interceptor blew up", e.getMessage());
-        } catch (IllegalStateException e) {
-            Assert.fail("Expected SkyflowException, got IllegalStateException");
-        }
-    }
-
-    @Test
     public void testBulkInsert_interceptorAddsCustomHeader() throws Exception {
         ApiClient mockApi = Mockito.mock(ApiClient.class);
         RawFlowserviceClient mockRaw = mockRawFlowservice(mockApi);

--- a/flowvault/src/test/java/com/skyflow/vault/data/ResponseComponentTests.java
+++ b/flowvault/src/test/java/com/skyflow/vault/data/ResponseComponentTests.java
@@ -144,6 +144,7 @@ public class ResponseComponentTests {
         Token token = new Token("tok-1", "group1");
         Assert.assertEquals("tok-1", token.getToken());
         Assert.assertEquals("group1", token.getTokenGroupName());
+        Assert.assertNull(token.getPath());
     }
 
     @Test
@@ -152,6 +153,14 @@ public class ResponseComponentTests {
         String json = token.toString();
         Assert.assertTrue(json.contains("tok-1"));
         Assert.assertTrue(json.contains("group1"));
+    }
+
+    @Test
+    public void testToken_threeArgConstructorSetsPath() {
+        Token token = new Token("tok-1", "group1", "street");
+        Assert.assertEquals("tok-1", token.getToken());
+        Assert.assertEquals("group1", token.getTokenGroupName());
+        Assert.assertEquals("street", token.getPath());
     }
 
     @Test
@@ -254,6 +263,36 @@ public class ResponseComponentTests {
     }
 
     @Test
+    public void testParseTokens_parsesPathForANestedColumnValue() {
+        // Real shape observed for a structured column (e.g. an "address" object) tokenized
+        // per nested field - see flowdb_dp_apis.proto's own example response.
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("token", "tok-a");
+        entry.put("tokenGroupName", "tg1");
+        entry.put("path", "phone_numbers[0].type");
+
+        Map<String, Object> rawTokens = new HashMap<>();
+        rawTokens.put("address", Collections.singletonList(entry));
+
+        List<Token> address = Token.parseTokens(rawTokens).get("address");
+        Assert.assertEquals("phone_numbers[0].type", address.get(0).getPath());
+    }
+
+    @Test
+    public void testParseTokens_mapEntryMissingPathKeyParsesAsNull() {
+        Map<String, Object> entry = new HashMap<>();
+        entry.put("token", "tok-a");
+        entry.put("tokenGroupName", "tg1");
+        // no "path" key - the normal case for a flat (non-structured) column.
+
+        Map<String, Object> rawTokens = new HashMap<>();
+        rawTokens.put("col1", entry);
+
+        List<Token> col1 = Token.parseTokens(rawTokens).get("col1");
+        Assert.assertNull(col1.get(0).getPath());
+    }
+
+    @Test
     public void testParseTokens_skipsNullEntriesWithinAList() {
         Map<String, Object> entry = new HashMap<>();
         entry.put("token", "tok-a");
@@ -284,6 +323,19 @@ public class ResponseComponentTests {
         Map<?, ?> entry = (Map<?, ?>) col1.get(0);
         Assert.assertEquals("tok-a", entry.get("token"));
         Assert.assertEquals("tg1", entry.get("tokenGroupName"));
+        // No path was set on the Token, so the rendered map has no such key at all - not a
+        // "path": null entry - keeping the path-less shape identical to before path existed.
+        Assert.assertFalse(entry.containsKey("path"));
+    }
+
+    @Test
+    public void testToRawTokens_rendersPathWhenPresent() {
+        Map<String, List<Token>> tokens = new HashMap<>();
+        tokens.put("address", Collections.singletonList(new Token("tok-a", "tg1", "street")));
+
+        Map<?, ?> entry = (Map<?, ?>) ((List<?>) Token.toRawTokens(tokens).get("address")).get(0);
+
+        Assert.assertEquals("street", entry.get("path"));
     }
 
     @Test


### PR DESCRIPTION
## Summary

### 1. `Token.getPath()`

`flowdb_dp_apis.proto`'s own literal example response for insert includes a `"path"` key on token entries for a structured column:

```json
"address": [
  {"path": "street", "token": "AMmmtFZyRO", "tokenGroupName": "nondet_trans_reg"},
  {"path": "phone_numbers[0].type", "token": "1e4c7e6b-...", "tokenGroupName": "det_rtf"}
]
```

— present when tokenizing a nested field within a structured column's own value, absent for flat columns (e.g. `"email"`, `"age"` in that same example never carry it). `Token.toToken()`/`parseTokens()` silently dropped this key entirely; nothing in the SDK exposed it.

- Added `Token.getPath()` (nullable) and a new 3-arg constructor `Token(token, tokenGroupName, path)`. The existing 2-arg constructor delegates to it with `path=null` — purely additive, no existing signature changed.
- `Token.parseTokens()` now reads `"path"` from each raw entry when present.
- `Token.toRawTokens()` (`getFields()`'s deprecated rendering) only adds a `"path"` key when the `Token` actually has one, rather than unconditionally — so a path-less round trip stays exactly as lossless as it was before `path` existed. (Adding it unconditionally would have given `testToRawTokens_isTheInverseOfParseTokensForMapShapedInput` a spurious `"path": null` key it never had — caught this while writing the fix, before it became a real regression.)
- Updated `Token`'s Javadoc and the README's Bulk Insert `Token` section.

**Compatibility:** purely additive — confirmed via `japicmp`: `BUILD SUCCESS`, zero incompatibilities, no baseline regen needed.

### 2. `flowvault/samples/pom.xml`'s stale dependency version

Pinned `skyflow-flowvault-java` to `3.0.0-beta.13-dev.18f8f1ba` — a private dev-build version string carried over by mistake from the unrelated `flowvault-release/26.8.1` branch when `b3cf7375` (`SK-3002 release/26.8.1` #386) switched the sample's dependency from `skyflow-java` (v2) to `skyflow-flowvault-java`. Pinned to `1.0.1`, the actual latest public GA release.

### 3. Revert: `bulkInsert` (sync) structural exception-handling fix from #412

#412's second commit moved `processBulkInsertSync`'s call to `insertBatchFutures` inside its own `try`, fixing a raw-exception leak via a throwing `RequestInterceptor`. Further investigation showed the same gap (missing `SkyflowException`-passthrough / generic `Exception` catch) exists identically in `bulkDetokenize`/`bulkDeleteTokens`/`bulkTokenize`'s own outer catch lists too — not just `bulkInsert`'s — so a narrower, operation-specific structural fix isn't the right shape for this. Reverted here pending a uniform fix across all four sync methods (tracked separately, not yet decided).

Removed `testBulkInsert_unexpectedExceptionWrappedAsSkyflowException`, which tested the now-reverted behavior.

## Testing

- `mvn -pl common,flowvault -am test -Dtest='!TokenTests#testExpiredTokenForIsExpiredToken' -DfailIfNoTests=false` → **708 tests, 0 failures**.
- `mvn -pl common,flowvault -am verify -Dgpg.skip=true` (same exclusion) → **BUILD SUCCESS**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)