### PR TITLE
chore: re-trigger internal-release workflow

### DIFF
--- a/flowvault/pom.xml
+++ b/flowvault/pom.xml
@@ -1,4 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
+<!-- chore: re-trigger internal-release -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
The previous two pushes to this branch didn't produce a real run of `internal-release.yml`:

1. The PR #413 merge commit's body happened to contain the literal substring `[AUTOMATED]` (in a sentence referencing another release), which tripped `resolve-module`'s `if: !contains(github.event.head_commit.message, '[AUTOMATED]')` guard and skipped the job.
2. A follow-up empty commit pushed directly to the branch produced no run at all — an empty diff vacuously satisfies the workflow's `paths-ignore: ["*.md"]` filter, so GitHub filters the whole run out before it's even created.

This PR makes an actual non-.md change (one comment line in `flowvault/pom.xml`) so merging it produces a real trigger for the release workflow.