### PR TITLE
SK-3061: fix bulkInsert(sync) interceptor-exception leak

### DIFF
--- a/flowvault/src/main/java/com/skyflow/vault/controller/VaultController.java
+++ b/flowvault/src/main/java/com/skyflow/vault/controller/VaultController.java
@@ -769,9 +769,9 @@ public final class VaultController extends VaultClient {
     ) throws ExecutionException, InterruptedException, SkyflowException {
         LogUtil.printInfoLog(InfoLogs.PROCESSING_BATCHES.getLog());
         List<BulkInsertResponseRecord> records = new ArrayList<>();
-        List<CompletableFuture<BulkInsertResponse>> futures = this.insertBatchFutures(insertRequest, interceptor, cfg);
 
         try {
+            List<CompletableFuture<BulkInsertResponse>> futures = this.insertBatchFutures(insertRequest, interceptor, cfg);
             CompletableFuture<Void> allFutures = CompletableFuture.allOf(futures.toArray(new CompletableFuture[0]));
             try {
                 allFutures.join();

--- a/flowvault/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
+++ b/flowvault/src/test/java/com/skyflow/vault/controller/VaultControllerTests.java
@@ -1164,4 +1164,30 @@ public class VaultControllerTests {
         Mockito.verify(mockRaw, Mockito.times(EXPECTED_BATCH_COUNT)).tokenize(any(), captor.capture());
         assertInterceptorRanOncePerBatch(interceptor, captor.getAllValues());
     }
+
+    @Test
+    public void testBulkInsert_throwingInterceptorWrappedAsSkyflowException() throws Exception {
+        ApiClient mockApi = Mockito.mock(ApiClient.class);
+        RawFlowserviceClient mockRaw = mockRawFlowservice(mockApi);
+        stubInsertEcho(mockRaw);
+        VaultController controller = createControllerWithMock(mockApi);
+
+        Map<String, Object> data = new HashMap<>();
+        data.put("name", "john");
+        ArrayList<InsertRequestRecord> records = new ArrayList<>();
+        records.add(BulkInsertRequestRecord.builder().tableName("table1").data(data).build());
+        BulkInsertRequest request = BulkInsertRequest.builder().records(records).build();
+
+        RequestInterceptor interceptor = ctx -> {
+            throw new IllegalStateException("sync insert interceptor blew up");
+        };
+        BulkInsertOptions options = BulkInsertOptions.builder().interceptor(interceptor).build();
+
+        try {
+            controller.bulkInsert(request, options);
+            Assert.fail(EXCEPTION_NOT_THROWN);
+        } catch (SkyflowException e) {
+            Assert.assertEquals("sync insert interceptor blew up", e.getMessage());
+        }
+    }
 }


### PR DESCRIPTION
## Problem

`processBulkInsertSync` called `insertBatchFutures` — which synchronously invokes the caller's `RequestInterceptor` — **before** entering its own try block. A throwing interceptor therefore escaped `bulkInsert()` as a raw, undeclared exception instead of the documented `SkyflowException`.

`processBulkDetokenizeSync`/`processBulkDeleteTokensSync`/`processBulkTokenizeSync` already call their own `*BatchFutures` **inside** their own `try/catch(Exception)`, which is why they weren't exploitable the same way — `bulkInsert` was the odd one out structurally.

## Fix

Moved the `insertBatchFutures(...)` call inside `processBulkInsertSync`'s existing try block, matching the other three private helpers' structure. No new catch clauses added to the public methods — this is the narrower, surgical fix (an earlier revision of this PR added a catch-all `Exception` to all 4 sync public methods; reverted in favor of this smaller, more targeted change).

## Testing

Added a regression test asserting a throwing `RequestInterceptor` surfaces as `SkyflowException` from `bulkInsert`, never raw. TDD'd against this change: failed before (raw `IllegalStateException` leaked), passes after.

`mvn -pl common,flowvault -am test` → 709 tests (flowvault) + 106 (common/ValidationsTests), 0 failures, BUILD SUCCESS.