### PR TITLE
chore: re-trigger internal-release workflow

### DIFF
--- a/flowvault/pom.xml
+++ b/flowvault/pom.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- chore: re-trigger internal-release -->
+<!-- chore: re-trigger internal-release (#416 merge commit false-skipped) -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">

--- a/flowvault/pom.xml
+++ b/flowvault/pom.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<!-- chore: re-trigger internal-release (#416 merge commit false-skipped) -->
 <project xmlns="http://maven.apache.org/POM/4.0.0"
          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">


### PR DESCRIPTION
PR #416's squash-merge commit (`e6a15f02`) concatenated every sub-commit message, including three `[AUTOMATED] Private Release ...` lines from the dev-release bumps along the way. That substring match tripped `resolve-module`'s `if: !contains(github.event.head_commit.message, '[AUTOMATED]')` guard (same false-skip as PR #413/#414 earlier), so both `resolve-module` and `build-and-deploy` were skipped on that push — see [run 32247361185](https://github.com/skyflowapi/skyflow-java/actions/runs/32247361185).

This PR makes an actual non-.md change (one comment line in `flowvault/pom.xml`) with a clean commit message so merging it produces a real trigger for the release workflow.