### PR TITLE
SK-3061: close tokenize patch-coverage gaps flagged on #420

### DIFF
--- a/.cspell.json
+++ b/.cspell.json
@@ -109,6 +109,7 @@
     "deserialise",
     "deserialised",
     "deserialises",
+    "unparseable",
     "unmodelled",
     "recordss",
     "rarr",

--- a/.cspell.json
+++ b/.cspell.json
@@ -108,6 +108,7 @@
     "synthesised",
     "deserialise",
     "deserialised",
+    "deserialises",
     "unmodelled",
     "recordss",
     "rarr",

--- a/flowvault/src/test/java/com/skyflow/utils/FlatTokenizeResponseTests.java
+++ b/flowvault/src/test/java/com/skyflow/utils/FlatTokenizeResponseTests.java
@@ -339,6 +339,77 @@ public class FlatTokenizeResponseTests {
     }
 
     @Test
+    public void testRejectedRequest_emptyResponseArrayFallsBackToTheStatusCode() {
+        // "response" is present but empty - nothing to rebuild from, so fall back like a body
+        // without a response array at all
+        List<BulkTokenizeRequestRecord> sent = Collections.singletonList(record("v1", "g1"));
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("response", new ArrayList<>());
+
+        List<BulkTokenizeResponseRecord> records =
+                Utils.handleBulkTokenizeBatchException(rejected(500, body), sent, 0);
+
+        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(Integer.valueOf(500), records.get(0).getHttpCode());
+    }
+
+    @Test
+    public void testRejectedRequest_explicitNullResponseArrayFallsBackToTheStatusCode() {
+        // "response" is present in the map but its value is JSON null, not an array - deserialises
+        // to an absent Optional rather than an empty one
+        List<BulkTokenizeRequestRecord> sent = Collections.singletonList(record("v1", "g1"));
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("response", null);
+
+        List<BulkTokenizeResponseRecord> records =
+                Utils.handleBulkTokenizeBatchException(rejected(500, body), sent, 0);
+
+        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(Integer.valueOf(500), records.get(0).getHttpCode());
+    }
+
+    @Test
+    public void testRejectedRequest_unparseableResponseArrayFallsBackToTheStatusCode() {
+        // "response" is present but the wrong shape to deserialise - must not propagate the crash
+        List<BulkTokenizeRequestRecord> sent = Collections.singletonList(record("v1", "g1"));
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("response", "not-an-array");
+
+        List<BulkTokenizeResponseRecord> records =
+                Utils.handleBulkTokenizeBatchException(rejected(500, body), sent, 0);
+
+        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(Integer.valueOf(500), records.get(0).getHttpCode());
+    }
+
+    @Test
+    public void testRejectedRequest_nullBatchWithPerRowBodyStillRebuildsFromTheRows() {
+        // defensive: a null batch can't be correlated against, but a per-row body still has
+        // everything needed to report each row directly
+        Throwable ex = rejected(400, body(row("v1", "g1", "", "bad group", 400)));
+
+        List<BulkTokenizeResponseRecord> records =
+                Utils.handleBulkTokenizeBatchException(ex, null, 0);
+
+        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(0, records.get(0).getIndex());
+        Assert.assertEquals("bad group", records.get(0).getError());
+    }
+
+    @Test
+    public void testRejectedRequest_emptyBatchWithPerRowBodyStillRebuildsFromTheRows() {
+        // same as a null batch - an empty one can't be correlated against either
+        Throwable ex = rejected(400, body(row("v1", "g1", "", "bad group", 400)));
+
+        List<BulkTokenizeResponseRecord> records =
+                Utils.handleBulkTokenizeBatchException(ex, new ArrayList<>(), 0);
+
+        Assert.assertEquals(1, records.size());
+        Assert.assertEquals(0, records.get(0).getIndex());
+        Assert.assertEquals("bad group", records.get(0).getError());
+    }
+
+    @Test
     public void testRejectedRequest_retryableStatusStillSurfacesForRetry() {
         List<BulkTokenizeRequestRecord> sent = Collections.singletonList(record("v1", "g1"));
         Throwable ex = rejected(503, body(row("v1", "g1", "", "service unavailable", 503)));

--- a/flowvault/src/test/java/com/skyflow/utils/UtilsTests.java
+++ b/flowvault/src/test/java/com/skyflow/utils/UtilsTests.java
@@ -1651,6 +1651,39 @@ public class UtilsTests {
     }
 
     @Test
+    public void testHandleBulkTokenizeBatchException_errorFieldAsObjectPrefersNestedErrorOverMessage() {
+        // extractBatchErrorMessage prefers a nested "error" key over "message" when both are present
+        Map<String, Object> errorObject = new HashMap<>();
+        errorObject.put("error", "nested error message");
+        errorObject.put("message", "vault not found");
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", errorObject);
+        ApiClientApiException apiEx = new ApiClientApiException("tokenize failed", 404, body);
+        RuntimeException wrapper = new RuntimeException(apiEx);
+
+        List<BulkTokenizeResponseRecord> errors = Utils.handleBulkTokenizeBatchException(
+                wrapper, tokenizeBatch("v1", "group1"), 0);
+
+        Assert.assertEquals("nested error message", errors.get(0).getError());
+    }
+
+    @Test
+    public void testHandleBulkTokenizeBatchException_errorFieldAsObjectWithoutAStringFallsBackToApiMessage() {
+        // neither "error" nor "message" is a String, so there is nothing usable to read out of it
+        Map<String, Object> errorObject = new HashMap<>();
+        errorObject.put("message", Collections.singletonList("not a string"));
+        Map<String, Object> body = new HashMap<>();
+        body.put("error", errorObject);
+        ApiClientApiException apiEx = new ApiClientApiException("tokenize failed", 404, body);
+        RuntimeException wrapper = new RuntimeException(apiEx);
+
+        List<BulkTokenizeResponseRecord> errors = Utils.handleBulkTokenizeBatchException(
+                wrapper, tokenizeBatch("v1", "group1"), 0);
+
+        Assert.assertEquals("tokenize failed", errors.get(0).getError());
+    }
+
+    @Test
     public void testHandleBulkTokenizeBatchException_nonMapBodyUsesApiMessage() {
         // Body is not a map, so extractBatchErrorMessage falls back to the exception's own message.
         ApiClientApiException apiEx = new ApiClientApiException("tokenize failed", 500, "raw string body");
@@ -1671,6 +1704,19 @@ public class UtilsTests {
         List<BulkTokenizeResponseRecord> errors = Utils.handleBulkTokenizeBatchException(ex, null, 0);
 
         Assert.assertTrue(errors.isEmpty());
+    }
+
+    @Test
+    public void testHandleBulkTokenizeBatchException_emptyGroupListStillReportsOneEntry() {
+        // an explicitly empty token group list, not a null one, must be treated the same way
+        RuntimeException ex = new RuntimeException("boom");
+        List<BulkTokenizeRequestRecord> batch = Collections.singletonList(
+                BulkTokenizeRequestRecord.builder().value("v1").tokenGroupNames(new ArrayList<>()).build());
+
+        List<BulkTokenizeResponseRecord> errors = Utils.handleBulkTokenizeBatchException(ex, batch, 0);
+
+        Assert.assertEquals(1, errors.size());
+        Assert.assertNull(errors.get(0).getTokenGroupName());
     }
 
     // ── formatBulkInsertResponse ───────────────────────────────────────────────
@@ -1977,6 +2023,12 @@ public class UtilsTests {
         Assert.assertNull(Utils.formatBulkTokenizeResponse(
                 V1FlowTokenizeResponse.builder().build(),
                 tokenizeBatch("value1", "group1"), 0, new HashMap<>()));
+    }
+
+    @Test
+    public void testFormatBulkTokenizeResponse_nullResponseReturnsNull() {
+        Assert.assertNull(Utils.formatBulkTokenizeResponse(
+                null, tokenizeBatch("value1", "group1"), 0, new HashMap<>()));
     }
 
     // Tests for getQueryRequestBody / buildQueryResponse / getGetRequestBody / buildGetResponse

--- a/flowvault/src/test/java/com/skyflow/vault/data/BulkRetryAndSummaryTests.java
+++ b/flowvault/src/test/java/com/skyflow/vault/data/BulkRetryAndSummaryTests.java
@@ -108,7 +108,42 @@ public class BulkRetryAndSummaryTests {
         Assert.assertNull(new BulkTokenizeResponse(new ArrayList<>()).getSummary());
     }
 
+    @Test
+    public void testTokenizeSummary_classifiesByRowsWhenNoPayloadIsGiven() {
+        // The two-arg constructor can still be called with a null payload; classification then
+        // falls back to the indexes actually present in records instead of the submitted list.
+        List<BulkTokenizeResponseRecord> records = Arrays.asList(
+                row(0, "g1", "t1", 200, null),
+                row(1, "g1", null, 400, "bad group"),
+                row(2, "g1", "t2", 200, null),
+                row(2, "g2", null, 400, "bad group"));
+
+        TokenizeSummary summary = new BulkTokenizeResponse(records, null).getSummary();
+
+        // without a submitted payload to count values from, totalTokens falls back to the row count
+        Assert.assertEquals(4, summary.getTotalTokens());
+        Assert.assertEquals(1, summary.getTotalTokenized());
+        Assert.assertEquals(1, summary.getTotalPartial());
+        Assert.assertEquals(1, summary.getTotalFailed());
+    }
+
+    @Test
+    public void testTokenizeSummary_nullRecordsAndNullPayloadYieldsZeroes() {
+        TokenizeSummary summary = new BulkTokenizeResponse(null, null).getSummary();
+
+        Assert.assertEquals(0, summary.getTotalTokens());
+        Assert.assertEquals(0, summary.getTotalTokenized());
+        Assert.assertEquals(0, summary.getTotalPartial());
+        Assert.assertEquals(0, summary.getTotalFailed());
+    }
+
     // ── BulkTokenizeResponse.getRecordsToRetry ────────────────────────────────
+
+    @Test
+    public void testTokenizeRetry_withNullRecordsReturnsEmpty() {
+        Assert.assertTrue(new BulkTokenizeResponse(null, Collections.singletonList(requestRecord("a")))
+                .getRecordsToRetry().isEmpty());
+    }
 
     @Test
     public void testTokenizeRetry_only5xxFailuresAreReturned() {


### PR DESCRIPTION
## Why

PR #420 (`flowvault-release/26.8.13` → `main`) was flagged by codecov: 94.16% patch coverage, with `BulkTokenizeResponse.java` and `Utils.java` among the files with missing lines. Both are from the Tokenize flattening work in #419.

## Goal

Trace each flagged line via jacoco and close the ones that are real, in-scope gaps rather than adding tests for coverage's sake. Non-goal: `VaultController.java`'s uncovered lines (from #412's exception-handling fix) and `Utils.java`'s `formatBulkDeleteTokensResponse()`/`isFailedRecord()` lines (DeleteTokens, not Tokenize) are out of scope here.

## Testing

- Added tests for: `buildSummary()`/`getRecordsToRetry()`'s no-payload fallback branch (including the partial-outcome and null+null cases), `tokenizeRecordsFromErrorBody()`'s empty/null/unparseable `"response"` cases, `groupTokenizeRows()`'s null/empty-batch fallback, `extractBatchErrorMessage()`'s nested-object branches, and `formatBulkTokenizeResponse(null, ...)`.
- Left two lines uncovered deliberately: `buildTokenizeResponseRecord()`'s `.get() != null` check on an `Optional` already known to be present is structurally unreachable-false per `Optional`'s own contract - not a real gap.
- `mvn -pl common,flowvault -am test`: 720 flowvault + 157 common, all green.

## Tech debt

None added - this is test-only.
